### PR TITLE
Basic authorization endpoint + .env changes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,15 @@ module.exports = {
         allowExpressions: true,
       },
     ],
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        vars: "all",
+        args: "after-used",
+        ignoreRestSiblings: false,
+        varsIgnorePattern: "^_",
+      },
+    ],
     // React
     "react/prop-types": "off",
     "react/react-in-jsx-scope": "off",

--- a/migrations/20201006040029-AddPasswordToUsers.ts
+++ b/migrations/20201006040029-AddPasswordToUsers.ts
@@ -1,0 +1,34 @@
+import Base from "db-migrate-base";
+
+/**
+ * Describe what your `up` migration does.
+ */
+export async function up(
+  db: Base,
+  callback: Base.CallbackFunction
+): Promise<void> {
+  db.addColumn(
+    "users",
+    "hashed_password",
+    {
+      type: "string",
+      notNull: true,
+    },
+    callback
+  );
+}
+
+/**
+ * Describe what your `down` migration does.
+ */
+export async function down(
+  db: Base,
+  callback: Base.CallbackFunction
+): Promise<void> {
+  db.removeColumn("users", "hashed_password", callback);
+}
+
+// eslint-disable-next-line no-underscore-dangle
+export const _meta = {
+  version: 1,
+};

--- a/migrations/20201006040029-AddPasswordToUsers.ts
+++ b/migrations/20201006040029-AddPasswordToUsers.ts
@@ -1,7 +1,7 @@
 import Base from "db-migrate-base";
 
 /**
- * Describe what your `up` migration does.
+ * Adds the hashed_password field to the users table.
  */
 export async function up(
   db: Base,
@@ -19,7 +19,7 @@ export async function up(
 }
 
 /**
- * Describe what your `down` migration does.
+ * Removes the hashed_password field to the users table.
  */
 export async function down(
   db: Base,

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@prisma/cli": "2.8.0",
     "@types/db-migrate-base": "^0.0.8",
+    "@types/next-auth": "^3.1.10",
     "@types/node": "^14.11.1",
     "@types/react": "^16.9.49",
     "@types/react-dom": "^16.9.8",

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,0 +1,51 @@
+import NextAuth from "next-auth";
+import Providers from "next-auth/providers";
+
+type AuthorizeDTO = {
+  email: string;
+  password: string;
+  inviteCode?: string;
+  // metadata: userData;
+}
+
+const options = {
+  // Configure one or more authentication providers
+  providers: [
+    Providers.Credentials({
+      name: "Credentials",
+      credentials: {
+        username: { label: "Email", type: "text", placeholder: "" },
+        password: {  label: "Password", type: "password" }
+      },
+      authorize: async (credentials: AuthorizeDTO) => {
+        
+        const user = users.findOne({ where: { email: credentials.email }});
+        if (!user) {
+            // Verify that they are specifying a valid invite code
+            credentials.inviteCode
+    
+            // This is a new user, let's sign them up and authenticate them
+            const newUser = user.create({
+                    ...,
+                    hashedPassword: hash(credentials.password)
+            });
+            return newUser; // TODO: Strip out hashedPassword
+        }
+        if (user.hashedPassword === hash(credentials.password)) {
+            // This is an existing user, let's see if their password matches
+            return user; // TODO: Strip out hashedPassword
+        } else {
+            // Password mismatch
+            throw new Error('No!!!!!!');
+        }
+    }
+    }
+    }),
+    // ...add more providers here
+  ],
+
+  // A database is optional, but required to persist accounts in a database
+  database: process.env.DATABASE_URL,
+};
+
+export default (req, res) => NextAuth(req, res, options);

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,16 +1,26 @@
 import NextAuth from "next-auth";
 import Providers from "next-auth/providers";
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient, users } from "@prisma/client";
+import { createHmac } from "crypto";
+import { NextApiRequest, NextApiResponse } from "next";
 
 type AuthorizeDTO = {
   email: string;
   password: string;
   inviteCode?: string;
   // metadata: userData;
-}
+};
 
 const prisma = new PrismaClient();
 
+const hash = (password: string): string => {
+  return createHmac("sha256", password).digest("hex");
+};
+
+const stripPassword = (user: users): Omit<users, "hashed_password"> => {
+  const { hashed_password: _hashedPassword, ...sanitizedUser } = user;
+  return sanitizedUser;
+};
 
 const options = {
   // Configure one or more authentication providers
@@ -19,38 +29,39 @@ const options = {
       name: "Credentials",
       credentials: {
         username: { label: "Email", type: "text", placeholder: "" },
-        password: {  label: "Password", type: "password" }
+        password: { label: "Password", type: "password" },
       },
       authorize: async (credentials: AuthorizeDTO) => {
-        const user = await prisma.users.findOne({ where: { email: credentials.email }});
+        const user = await prisma.users.findOne({
+          where: { email: credentials.email },
+        });
         if (!user) {
-            // This is a new user, let's sign them up and authenticate them
-            const newUser = await prisma.users.create({
-              data: {
-                email: credentials.email
-                //  : hash(credentials.password)
-              }
-                    
-            });
-            return newUser; // TODO: Strip out hashedPassword
-        } 
-        // Verify that they are specifying a valid invite code
-        credentials.inviteCode;
-        if (user.hashedPassword === hash(credentials.password)) {
-            // This is an existing user, let's see if their password matches
-            return user; // TODO: Strip out hashedPassword
-        } else {
-            // Password mismatch
-            throw new Error('No!!!!!!');
+          // This is a new user, let's sign them up and authenticate them
+          const newUser = await prisma.users.create({
+            data: {
+              email: credentials.email,
+              hashed_password: hash(credentials.password),
+            },
+          });
+          return stripPassword(newUser);
         }
-    }
-    }
+        // Verify that they are specifying a valid invite code
+        // credentials.inviteCode;
+        if (user.hashed_password === hash(credentials.password)) {
+          // This is an existing user, let's see if their password matches
+          return stripPassword(user);
+        }
+        // Password mismatch
+        throw new Error("Invalid password");
+      },
     }),
-    // ...add more providers here
   ],
 
   // A database is optional, but required to persist accounts in a database
   database: process.env.DATABASE_URL,
 };
 
-export default (req, res) => NextAuth(req, res, options);
+export default (
+  req: NextApiRequest,
+  res: NextApiResponse<unknown>
+): Promise<void> => NextAuth(req, res, options);

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -8,7 +8,6 @@ type AuthorizeDTO = {
   email: string;
   password: string;
   inviteCode?: string;
-  // metadata: userData;
 };
 
 const prisma = new PrismaClient();
@@ -46,7 +45,6 @@ const options = {
           return stripPassword(newUser);
         }
         // Verify that they are specifying a valid invite code
-        // credentials.inviteCode;
         if (user.hashed_password === hash(credentials.password)) {
           // This is an existing user, let's see if their password matches
           return stripPassword(user);
@@ -57,7 +55,6 @@ const options = {
     }),
   ],
 
-  // A database is optional, but required to persist accounts in a database
   database: process.env.DATABASE_URL,
   session: {
     jwt: true,

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -32,7 +32,7 @@ const options = {
         password: { label: "Password", type: "password" },
       },
       authorize: async (credentials: AuthorizeDTO) => {
-        const user = await prisma.users.findOne({
+        const user = await prisma.users.findFirst({
           where: { email: credentials.email },
         });
         if (!user) {
@@ -59,6 +59,12 @@ const options = {
 
   // A database is optional, but required to persist accounts in a database
   database: process.env.DATABASE_URL,
+  session: {
+    jwt: true,
+  },
+  jwt: {
+    secret: process.env.JWT_SIGNING_PRIVATE_KEY,
+  },
 };
 
 export default (

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,13 +42,14 @@ model sessions {
 }
 
 model users {
-  id             Int       @id @default(autoincrement())
-  name           String?
-  email          String?   @unique
-  email_verified DateTime?
-  image          String?
-  created_at     DateTime  @default(now())
-  updated_at     DateTime  @default(now())
+  id              Int       @id @default(autoincrement())
+  name            String?
+  email           String?   @unique
+  email_verified  DateTime?
+  image           String?
+  created_at      DateTime  @default(now())
+  updated_at      DateTime  @default(now())
+  hashed_password String
 }
 
 model verification_requests {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1130,6 +1130,16 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/next-auth@^3.1.10":
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/@types/next-auth/-/next-auth-3.1.10.tgz#d9ca9957279c02ef11797e3ba4089b11ccca047f"
+  integrity sha512-elK/OUw9HhXiaL9y4etxj2CGltF+P89rcWNq/TdeIQL0a8cM26t8n1wuEyyUwJmLFa65WLfUePc1L0oqSV3Vmg==
+  dependencies:
+    "@types/node" "*"
+    "@types/react" "*"
+    jose "^1.28.0"
+    typeorm "^0.2.24"
+
 "@types/node@*", "@types/node@^14.11.1":
   version "14.11.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.2.tgz#2de1ed6670439387da1c9f549a2ade2b0a799256"
@@ -2578,10 +2588,9 @@ db-migrate-pg@^1.2.2:
     pg "^8.0.3"
     semver "^5.0.3"
 
-db-migrate-plugin-typescript@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/db-migrate-plugin-typescript/-/db-migrate-plugin-typescript-2.0.0.tgz#1fe18b7522d22b03fa0c7f0de5430dde49b0794a"
-  integrity sha512-I3vWzpXvftOUjC/aPPxTbfW7m0iCacHvB6hcFnvyzWOtERpJtFglRvSqbV1qrAzxyRTtzTmdKFaPZWIpXA70fQ==
+db-migrate-plugin-typescript@ethanlee16/plugin-typescript:
+  version "2.0.1"
+  resolved "https://codeload.github.com/ethanlee16/plugin-typescript/tar.gz/7e881bec7073dc37c6fbc1580c1274fc3654c680"
 
 db-migrate-shared@^1.2.0:
   version "1.2.0"
@@ -4104,7 +4113,7 @@ jest-worker@24.9.0:
     merge-stream "^2.0.0"
     supports-color "^6.1.0"
 
-jose@^1.27.2:
+jose@^1.27.2, jose@^1.28.0:
   version "1.28.0"
   resolved "https://registry.yarnpkg.com/jose/-/jose-1.28.0.tgz#0803f8c71f43cd293a9d931c555c30531f5ca5dc"
   integrity sha512-JmfDRzt/HSj8ipd9TsDtEHoLUnLYavG+7e8F6s1mx2jfVSfXOTaFQsJUydbjJpTnTDHP1+yKL9Ke7ktS/a0Eiw==


### PR DESCRIPTION
# Basic authorization endpoint + .env changes
- Wrote starting code for the NextAuth account authorization endpoint (with much support and guidance from @ethanlee16)
- Added migration for storing password
- Updated ts eslint no-unused-vars rule 

## Related PRs

@shannonmhong @christopher-grey take a look at [line 11 in [...nextauth].ts](https://github.com/calblueprint/ogsc/commit/7961dbaa16222dbfffe6173c51675016fd164f93#diff-3f0eb5f8ea11c33e06c794b69418f4eeL11), was thinking user metadata (i.e. viewing permissions) could be stored in the `AuthorizeDTO` user type?

## Breaking Changes
- Run yarn (added NextAuth types)
- Add the database url to the root `.env` file (the line that is already in your `prisma/.env` file)
`DATABASE_URL=postgresql://joydong:@localhost:5432/ogsc_development`


## Migrations

- **AddPasswordToUsers**: Adds a `hashed_password` field to the `users` table

## Screenshots

<img width="1426" alt="Screen Shot 2020-10-05 at 10 25 00 PM" src="https://user-images.githubusercontent.com/34170094/95162087-a19f7d80-0759-11eb-93d5-faa0e8467c1f.png">


CC: @erinysong
