### PR TITLE
Add user invites table + fix some Prisma model names

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/migrations/20201009072158-UniquePlayerUserIdConstraint.ts
+++ b/migrations/20201009072158-UniquePlayerUserIdConstraint.ts
@@ -1,0 +1,62 @@
+import Base from "db-migrate-base";
+
+/**
+ * Add the UNIQUE constraint to the user_id column of players.
+ */
+export async function up(
+  db: Base,
+  callback: Base.CallbackFunction
+): Promise<void> {
+  db.changeColumn(
+    "players",
+    "user_id",
+    {
+      type: "int",
+      notNull: true,
+      unique: true,
+      foreignKey: {
+        name: "fk_players_user_id",
+        table: "users",
+        rules: {
+          onDelete: "CASCADE",
+          onUpdate: "RESTRICT",
+        },
+        mapping: "id",
+      },
+    },
+    callback
+  );
+}
+
+/**
+ * Remove the UNIQUE constraint from the user_id column of players.
+ */
+export async function down(
+  db: Base,
+  callback: Base.CallbackFunction
+): Promise<void> {
+  db.changeColumn(
+    "players",
+    "user_id",
+    {
+      type: "int",
+      notNull: true,
+      unique: false,
+      foreignKey: {
+        name: "fk_players_user_id",
+        table: "users",
+        rules: {
+          onDelete: "CASCADE",
+          onUpdate: "RESTRICT",
+        },
+        mapping: "id",
+      },
+    },
+    callback
+  );
+}
+
+// eslint-disable-next-line no-underscore-dangle
+export const _meta = {
+  version: 1,
+};

--- a/migrations/20201009074558-AddUUIDExtension.ts
+++ b/migrations/20201009074558-AddUUIDExtension.ts
@@ -1,0 +1,26 @@
+import Base from "db-migrate-base";
+
+/**
+ * Add the UUID extension to the PostgreSQL database.
+ */
+export async function up(
+  db: Base,
+  callback: Base.CallbackFunction
+): Promise<void> {
+  db.runSql('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";', callback);
+}
+
+/**
+ * Remove the UUID extension from the PostgreSQL database.
+ */
+export async function down(
+  db: Base,
+  callback: Base.CallbackFunction
+): Promise<void> {
+  db.runSql('DROP EXTENSION IF EXISTS "uuid-ossp";', callback);
+}
+
+// eslint-disable-next-line no-underscore-dangle
+export const _meta = {
+  version: 1,
+};

--- a/migrations/20201009074559-CreateUserInvitesTable.ts
+++ b/migrations/20201009074559-CreateUserInvitesTable.ts
@@ -1,0 +1,57 @@
+/* eslint-disable no-new-wrappers */
+import Base from "db-migrate-base";
+
+/**
+ * Creates the user_invites table initial structure.
+ */
+export async function up(
+  db: Base,
+  callback: Base.CallbackFunction
+): Promise<void> {
+  db.createTable(
+    "user_invites",
+    {
+      id: {
+        type: "uuid",
+        notNull: true,
+        primaryKey: true,
+        defaultValue: new String("uuid_generate_v4()"),
+      },
+      created_at: {
+        type: "datetime",
+        notNull: true,
+        defaultValue: new String("NOW()"),
+      },
+      user_id: {
+        type: "int",
+        unsigned: true,
+        notNull: true,
+        foreignKey: {
+          name: "fk_user_invites_user_id",
+          table: "users",
+          mapping: "id",
+          rules: {
+            onDelete: "RESTRICT",
+            onUpdate: "CASCADE",
+          },
+        },
+      },
+    },
+    callback
+  );
+}
+
+/**
+ * Drops the user_invites table.
+ */
+export async function down(
+  db: Base,
+  callback: Base.CallbackFunction
+): Promise<void> {
+  db.dropTable("user_invites", callback);
+}
+
+// eslint-disable-next-line no-underscore-dangle
+export const _meta = {
+  version: 1,
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,6 +7,20 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+model User {
+  id             Int       @id @default(autoincrement())
+  name           String?
+  email          String?   @unique
+  emailVerified  DateTime? @map("email_verified")
+  image          String?
+  createdAt      DateTime  @default(now()) @map("created_at")
+  updatedAt      DateTime  @default(now()) @map("updated_at")
+  hashedPassword String    @map("hashed_password")
+  players        players[]
+
+  @@map("users")
+}
+
 model migrations {
   id     Int      @id @default(autoincrement())
   name   String
@@ -41,18 +55,6 @@ model sessions {
   updated_at    DateTime @default(now())
 }
 
-model users {
-  id              Int       @id @default(autoincrement())
-  name            String?
-  email           String?   @unique
-  email_verified  DateTime?
-  image           String?
-  created_at      DateTime  @default(now())
-  updated_at      DateTime  @default(now())
-  hashed_password String
-  players        players[]
-}
-
 model verification_requests {
   id         Int      @id @default(autoincrement())
   identifier String
@@ -81,5 +83,5 @@ model players {
   beep_test                    String?
   mile_time                    String?
   highlights                   String?
-  users                        users   @relation(fields: [user_id], references: [id])
+  users                        User    @relation(fields: [user_id], references: [id])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,15 +8,16 @@ datasource db {
 }
 
 model User {
-  id             Int       @id @default(autoincrement())
+  id             Int          @id @default(autoincrement())
   name           String?
-  email          String?   @unique
-  emailVerified  DateTime? @map("email_verified")
+  email          String?      @unique
+  emailVerified  DateTime?    @map("email_verified")
   image          String?
-  createdAt      DateTime  @default(now()) @map("created_at")
-  updatedAt      DateTime  @default(now()) @map("updated_at")
-  hashedPassword String    @map("hashed_password")
+  createdAt      DateTime     @default(now()) @map("created_at")
+  updatedAt      DateTime     @default(now()) @map("updated_at")
+  hashedPassword String       @map("hashed_password")
   player         Player?
+  userInvites    UserInvite[] @relation("user_invitesTousers")
 
   @@map("users")
 }
@@ -86,4 +87,13 @@ model Player {
   user                        User    @relation(fields: [user_id], references: [id])
 
   @@map("players")
+}
+
+model UserInvite {
+  id         String   @id @default(dbgenerated())
+  created_at DateTime @default(now())
+  user_id    Int
+  user       User     @relation("user_invitesTousers", fields: [user_id], references: [id])
+
+  @@map("user_invites")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,7 +16,7 @@ model User {
   createdAt      DateTime  @default(now()) @map("created_at")
   updatedAt      DateTime  @default(now()) @map("updated_at")
   hashedPassword String    @map("hashed_password")
-  players        players[]
+  player         Player?
 
   @@map("users")
 }
@@ -64,24 +64,26 @@ model verification_requests {
   updated_at DateTime @default(now())
 }
 
-model players {
-  user_id                      Int     @id
-  bio                          String?
-  academic_engagement_score    Int?
-  academic_engagement_comments String?
-  advising_score               Int?
-  advising_comments            String?
-  athletic_score               Int?
-  athletic_comments            String?
-  gpa                          Float?
-  disciplinary_actions         String?
-  school_absences              String?
-  advising_absences            String?
-  athletic_absences            String?
-  bmi                          Float?
-  health_and_wellness          String?
-  beep_test                    String?
-  mile_time                    String?
-  highlights                   String?
-  users                        User    @relation(fields: [user_id], references: [id])
+model Player {
+  user_id                     Int     @id
+  bio                         String?
+  academicEngagementScore     Int?    @map("academic_engagement_score")
+  acaademicEngagementComments String? @map("academic_engagement_comments")
+  advisingScore               Int?    @map("advising_score")
+  advisingComments            String? @map("advising_comments")
+  athleticScore               Int?    @map("athletic_score")
+  athleticComments            String? @map("athletic_comments")
+  gpa                         Float?
+  disciplinaryActions         String? @map("disciplinary_actions")
+  schoolAbsences              String? @map("school_absences")
+  advisingAbsences            String? @map("advising_absences")
+  athleticAbsences            String? @map("athletic_absences")
+  bmi                         Float?
+  healthAndWellness           String? @map("health_and_wellness")
+  beepTest                    String? @map("beep_test")
+  mileTime                    String? @map("mile_time")
+  highlights                  String?
+  user                        User    @relation(fields: [user_id], references: [id])
+
+  @@map("players")
 }


### PR DESCRIPTION
* Updates some Prisma model names to PascalCase singular form, with the use of `@map` and `@@map` annotations
* Creates `user_invites` table

## Migrations

* `20201009074558-AddUUIDExtension`: The primary key of `user_invites` is a string type, auto-generated UUID. This migration adds the UUID extension to the PostgreSQL database, if it doesn't already have it.
* `20201009074559-CreateUserInvitesTable`: Creates the `user_invites` table.

CC: @erinysong
