### PR TITLE
Add getInviteById API route + break out sanitizeUser shared function

### DIFF
--- a/interfaces/index.ts
+++ b/interfaces/index.ts
@@ -1,10 +1,3 @@
-// You can include shared interfaces/types in a separate file
-// and then use them in any component by importing them. For
-// example, to import the interface below do:
-//
-// import User from 'path/to/interfaces';
+import { User } from "@prisma/client";
 
-export type User = {
-  id: number;
-  name: string;
-};
+export type SanitizedUser = Omit<User, "hashedPassword">;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "next": "9.5.3",
     "next-auth": "^3.1.0",
     "react": "16.13.1",
-    "react-dom": "16.13.1"
+    "react-dom": "16.13.1",
+    "validator": "^13.1.17"
   },
   "devDependencies": {
     "@prisma/cli": "2.8.0",
@@ -37,6 +38,7 @@
     "@types/node": "^14.11.1",
     "@types/react": "^16.9.49",
     "@types/react-dom": "^16.9.8",
+    "@types/validator": "^13.1.0",
     "@typescript-eslint/eslint-plugin": "^4.2.0",
     "@typescript-eslint/parser": "^4.2.0",
     "babel-eslint": "^10.1.0",

--- a/pages/api/invites/[id].ts
+++ b/pages/api/invites/[id].ts
@@ -1,0 +1,48 @@
+import { PrismaClient, UserInvite } from "@prisma/client";
+import { SanitizedUser } from "interfaces";
+import { NextApiRequest, NextApiResponse } from "next";
+import sanitizeUser from "utils/sanitizeUser";
+import isUUID from "validator/lib/isUUID";
+
+const prisma = new PrismaClient();
+
+/**
+ * Retrieve a UserInvite by its UUID and include the user object.
+ * @param id - the ID of the UserInvite
+ */
+export const getInviteById = async (
+  id: string
+): Promise<(UserInvite & { user: SanitizedUser }) | null> => {
+  if (!isUUID(id)) {
+    return null;
+  }
+  const invite = await prisma.userInvite.findOne({
+    where: { id },
+    include: { user: true },
+  });
+  if (!invite) {
+    return null;
+  }
+  return { ...invite, user: sanitizeUser(invite.user) };
+};
+
+const handler = async (
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> => {
+  const id = req.query.id as string;
+  try {
+    const userInvite = await getInviteById(id);
+    if (userInvite) {
+      res.status(200).json(userInvite);
+    } else {
+      res
+        .status(404)
+        .json({ statusCode: 404, message: "Could not find invite" });
+    }
+  } catch (err) {
+    res.status(500).json({ statusCode: 500, message: err.message });
+  }
+};
+
+export default handler;

--- a/utils/sanitizeUser.ts
+++ b/utils/sanitizeUser.ts
@@ -1,0 +1,13 @@
+import { User } from "@prisma/client";
+import { SanitizedUser } from "interfaces";
+
+/**
+ * Remove unsafe fields from our internal DB representation of a user, for use on the client.
+ * @param user - the original User object fetched with Prisma
+ */
+const sanitizeUser = (user: User): SanitizedUser => {
+  const { hashedPassword: _hashedPassword, ...sanitizedUser } = user;
+  return sanitizedUser;
+};
+
+export default sanitizeUser;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1170,6 +1170,11 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
+"@types/validator@^13.1.0":
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.1.0.tgz#3d776127dbce7dd31fc06f86d3428b072e631eba"
+  integrity sha512-gHUHI6pJaANIO2r6WcbT7+WMgbL9GZooR4tWpuBOETpDIqFNxwaJluE+6rj6VGYe8k6OkfhbHz2Fkm8kl06Igw==
+
 "@typescript-eslint/eslint-plugin@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.2.0.tgz#a3d5c11b377b7e18f3cd9c4e87d465fe9432669b"
@@ -6989,6 +6994,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+validator@^13.1.17:
+  version "13.1.17"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.1.17.tgz#ad677736950adddd3c37209484a6b2e0966579ad"
+  integrity sha512-zL5QBoemJ3jYFb2/j38y7ljhwYGXVLUp8H6W1nVxadnAOvUOytec+L7BHh1oBQ82/TzWXHd+GSaxUWp4lROkLg==
 
 vm-browserify@1.1.2, vm-browserify@^1.0.1:
   version "1.1.2"


### PR DESCRIPTION
* Adds an API route/reusable function for getting an invite by its ID (this ID would be included in the invite link URL)
* Breaks out `stripPassword` function into generic utility for `sanitizeUser`, with `SanitizedUser` type

CC: @erinysong
