### PR TITLE
Schema hotfix, move to Joi for validation, resolve type errors

### DIFF
--- a/components/List.tsx
+++ b/components/List.tsx
@@ -1,4 +1,4 @@
-import { User } from "interfaces";
+import { User } from "utils/sample-data";
 import ListItem from "./ListItem";
 
 type Props = {

--- a/components/ListDetail.tsx
+++ b/components/ListDetail.tsx
@@ -1,4 +1,4 @@
-import { User } from "interfaces";
+import { User } from "utils/sample-data";
 
 type ListDetailProps = {
   item: User;

--- a/components/ListItem.tsx
+++ b/components/ListItem.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-import { User } from "interfaces";
+import { User } from "utils/sample-data";
 
 type Props = {
   data: User;

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
     "@prisma/client": "2.8.0",
     "db-migrate": "^0.11.11",
     "db-migrate-base": "^2.3.0",
+    "joi": "^17.2.1",
     "next": "9.5.3",
     "next-auth": "^3.1.0",
     "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "validator": "^13.1.17"
+    "react-dom": "16.13.1"
   },
   "devDependencies": {
     "@prisma/cli": "2.8.0",
@@ -38,7 +38,6 @@
     "@types/node": "^14.11.1",
     "@types/react": "^16.9.49",
     "@types/react-dom": "^16.9.8",
-    "@types/validator": "^13.1.0",
     "@typescript-eslint/eslint-plugin": "^4.2.0",
     "@typescript-eslint/parser": "^4.2.0",
     "babel-eslint": "^10.1.0",

--- a/pages/api/hello.ts
+++ b/pages/api/hello.ts
@@ -1,7 +1,7 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 import { NextApiRequest, NextApiResponse } from "next";
 
-export default (req: NextApiRequest, res: NextApiResponse): void => {
+export default (_req: NextApiRequest, res: NextApiResponse): void => {
   res.statusCode = 200;
   res.json({ name: "John Doe" });
 };

--- a/pages/api/invites/[id].ts
+++ b/pages/api/invites/[id].ts
@@ -1,8 +1,8 @@
 import { PrismaClient, UserInvite } from "@prisma/client";
 import { SanitizedUser } from "interfaces";
+import Joi from "joi";
 import { NextApiRequest, NextApiResponse } from "next";
 import sanitizeUser from "utils/sanitizeUser";
-import isUUID from "validator/lib/isUUID";
 
 const prisma = new PrismaClient();
 
@@ -13,7 +13,7 @@ const prisma = new PrismaClient();
 export const getInviteById = async (
   id: string
 ): Promise<(UserInvite & { user: SanitizedUser }) | null> => {
-  if (!isUUID(id)) {
+  if (Joi.string().uuid({ version: "uuidv4" }).validate(id)) {
     return null;
   }
   const invite = await prisma.userInvite.findOne({

--- a/pages/users/[id].tsx
+++ b/pages/users/[id].tsx
@@ -1,7 +1,6 @@
 import { GetStaticProps, GetStaticPaths } from "next";
 
-import { User } from "interfaces";
-import { sampleUserData } from "utils/sample-data";
+import { User, sampleUserData } from "utils/sample-data";
 import Layout from "components/Layout";
 import ListDetail from "components/ListDetail";
 

--- a/pages/users/index.tsx
+++ b/pages/users/index.tsx
@@ -1,8 +1,7 @@
 import { GetStaticProps } from "next";
 import Link from "next/link";
 
-import { User } from "interfaces";
-import { sampleUserData } from "utils/sample-data";
+import { User, sampleUserData } from "utils/sample-data";
 import Layout from "components/Layout";
 import List from "components/List";
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,16 +8,18 @@ datasource db {
 }
 
 model User {
-  id             Int          @id @default(autoincrement())
-  name           String?
-  email          String?      @unique
-  emailVerified  DateTime?    @map("email_verified")
-  image          String?
-  createdAt      DateTime     @default(now()) @map("created_at")
-  updatedAt      DateTime     @default(now()) @map("updated_at")
-  hashedPassword String       @map("hashed_password")
-  player         Player?
-  userInvites    UserInvite[] @relation("user_invitesTousers")
+  id                  Int                 @id @default(autoincrement())
+  name                String?
+  email               String?             @unique
+  emailVerified       DateTime?           @map("email_verified")
+  image               String?
+  createdAt           DateTime            @default(now()) @map("created_at")
+  updatedAt           DateTime            @default(now()) @map("updated_at")
+  hashedPassword      String              @map("hashed_password")
+  player              Player?
+  userInvites         UserInvite[]        @relation("UserInvitesToUsers")
+  viewedByPermissions ViewingPermission[] @relation("UsersToViewees")
+  viewerPermissions   ViewingPermission[] @relation("UsersToViewers")
 
   @@map("users")
 }
@@ -54,19 +56,6 @@ model sessions {
   access_token  String   @unique
   created_at    DateTime @default(now())
   updated_at    DateTime @default(now())
-}
-
-model users {
-  id                  Int                   @id @default(autoincrement())
-  name                String?
-  email               String?               @unique
-  email_verified      DateTime?
-  image               String?
-  created_at          DateTime              @default(now())
-  updated_at          DateTime              @default(now())
-  players             Player[]
-  viewedByPermissions viewing_permissions[] @relation("UsersToViewees")
-  viewerPermissions   viewing_permissions[] @relation("UsersToViewers")
 }
 
 model verification_requests {
@@ -106,16 +95,18 @@ model UserInvite {
   id         String   @id @default(dbgenerated())
   created_at DateTime @default(now())
   user_id    Int
-  user       User     @relation("user_invitesTousers", fields: [user_id], references: [id])
+  user       User     @relation("UserInvitesToUsers", fields: [user_id], references: [id])
 
   @@map("user_invites")
 }
 
-model viewing_permissions {
+model ViewingPermission {
   id                Int     @id
   viewer_id         Int?
   viewee_id         Int?
   relationship_type String?
-  viewee            users?  @relation("UsersToViewees", fields: [viewee_id], references: [id])
-  viewer            users?  @relation("UsersToViewers", fields: [viewer_id], references: [id])
+  viewee            User?   @relation("UsersToViewees", fields: [viewee_id], references: [id])
+  viewer            User?   @relation("UsersToViewers", fields: [viewer_id], references: [id])
+
+  @@map("viewing_permissions")
 }

--- a/utils/sample-data.ts
+++ b/utils/sample-data.ts
@@ -1,4 +1,7 @@
-import { User } from "interfaces";
+export type User = {
+  id: number;
+  name: string;
+};
 
 /** Dummy user data. */
 // eslint-disable-next-line import/prefer-default-export

--- a/yarn.lock
+++ b/yarn.lock
@@ -1038,6 +1038,35 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@hapi/address@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-4.1.0.tgz#d60c5c0d930e77456fdcde2598e77302e2955e1d"
+  integrity sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@hapi/formula@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/formula/-/formula-2.0.0.tgz#edade0619ed58c8e4f164f233cda70211e787128"
+  integrity sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A==
+
+"@hapi/hoek@^9.0.0":
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.1.0.tgz#6c9eafc78c1529248f8f4d92b0799a712b6052c6"
+  integrity sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw==
+
+"@hapi/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/pinpoint/-/pinpoint-2.0.0.tgz#805b40d4dbec04fc116a73089494e00f073de8df"
+  integrity sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw==
+
+"@hapi/topo@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.0.0.tgz#c19af8577fa393a06e9c77b60995af959be721e7"
+  integrity sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
 "@next/react-dev-overlay@9.5.3":
   version "9.5.3"
   resolved "https://registry.yarnpkg.com/@next/react-dev-overlay/-/react-dev-overlay-9.5.3.tgz#3275301f08045ecc709e3273031973a1f5e81427"
@@ -1131,7 +1160,6 @@
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
 "@types/next-auth@^3.1.10":
-
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/@types/next-auth/-/next-auth-3.1.10.tgz#d9ca9957279c02ef11797e3ba4089b11ccca047f"
   integrity sha512-elK/OUw9HhXiaL9y4etxj2CGltF+P89rcWNq/TdeIQL0a8cM26t8n1wuEyyUwJmLFa65WLfUePc1L0oqSV3Vmg==
@@ -1170,11 +1198,6 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
-
-"@types/validator@^13.1.0":
-  version "13.1.0"
-  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.1.0.tgz#3d776127dbce7dd31fc06f86d3428b072e631eba"
-  integrity sha512-gHUHI6pJaANIO2r6WcbT7+WMgbL9GZooR4tWpuBOETpDIqFNxwaJluE+6rj6VGYe8k6OkfhbHz2Fkm8kl06Igw==
 
 "@typescript-eslint/eslint-plugin@^4.2.0":
   version "4.2.0"
@@ -4119,6 +4142,17 @@ jest-worker@24.9.0:
     merge-stream "^2.0.0"
     supports-color "^6.1.0"
 
+joi@^17.2.1:
+  version "17.2.1"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.2.1.tgz#e5140fdf07e8fecf9bc977c2832d1bdb1e3f2a0a"
+  integrity sha512-YT3/4Ln+5YRpacdmfEfrrKh50/kkgX3LgBltjqnlMPIYiZ4hxXZuVJcxmsvxsdeHg9soZfE3qXxHC2tMpCCBOA==
+  dependencies:
+    "@hapi/address" "^4.1.0"
+    "@hapi/formula" "^2.0.0"
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/pinpoint" "^2.0.0"
+    "@hapi/topo" "^5.0.0"
+
 jose@^1.27.2, jose@^1.28.0:
   version "1.28.0"
   resolved "https://registry.yarnpkg.com/jose/-/jose-1.28.0.tgz#0803f8c71f43cd293a9d931c555c30531f5ca5dc"
@@ -6995,11 +7029,6 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
-
-validator@^13.1.17:
-  version "13.1.17"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-13.1.17.tgz#ad677736950adddd3c37209484a6b2e0966579ad"
-  integrity sha512-zL5QBoemJ3jYFb2/j38y7ljhwYGXVLUp8H6W1nVxadnAOvUOytec+L7BHh1oBQ82/TzWXHd+GSaxUWp4lROkLg==
 
 vm-browserify@1.1.2, vm-browserify@^1.0.1:
   version "1.1.2"


### PR DESCRIPTION
This addresses a couple current issues present in the main branch:
* Duplicate `User` and `users` models in Prisma schema. This might have been the result of a merge commit. **If you were previously using `prisma.users`, please update references to `prisma.user`!**
* Type errors in some of the placeholder pages/components as a result of deleting the placeholder `User` interface. I moved this interface to `utils/sample-data` for now (until these placeholders are deleted) to avoid confusion with our actual User/SanitizedUser interfaces.

This PR also switches out the `validator` package for [`joi`](https://joi.dev/api/?v=17.2.1), which will be produce more readable code for validating nested objects like `req.body` in our Next API routes. I've demonstrated the use of Joi at the end of a video on our [Slack channel](https://calblueprint.slack.com/archives/C01ALAUM1T9/p1602396741104700).

CC: @erinysong
