### PR TITLE
Finished account creation flow / endpoint

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -23,23 +23,14 @@ const options = {
         password: { label: "Password", type: "password" },
       },
       authorize: async (credentials: AuthorizeDTO) => {
-        const user = await prisma.user.findFirst({
+        const user = await prisma.user.findOne({
           where: { email: credentials.email },
         });
         if (!user) {
-          // This is a new user, let's sign them up and authenticate them
-          // call createAccount endpoint
-          // const newUser = await prisma.user.create({
-          //   data: {
-          //     email: credentials.email,
-          //     hashedPassword: hashPassword(credentials.password),
-          //   },
-          // });
-          // return sanitizeUser(newUser);
+          throw new Error("No account exists");
         }
-        // Verify that they are specifying a valid invite code
+        // Verify that their password matches
         if (user.hashedPassword === hashPassword(credentials.password)) {
-          // This is an existing user, let's see if their password matches
           return sanitizeUser(user);
         }
         // Password mismatch

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,8 +1,8 @@
 import NextAuth from "next-auth";
 import Providers from "next-auth/providers";
 import { PrismaClient } from "@prisma/client";
-import { createHmac } from "crypto";
 import { NextApiRequest, NextApiResponse } from "next";
+import hashPassword from "utils/hashPassword";
 import sanitizeUser from "utils/sanitizeUser";
 
 type AuthorizeDTO = {
@@ -12,10 +12,6 @@ type AuthorizeDTO = {
 };
 
 const prisma = new PrismaClient();
-
-const hash = (password: string): string => {
-  return createHmac("sha256", password).digest("hex");
-};
 
 const options = {
   // Configure one or more authentication providers
@@ -32,16 +28,17 @@ const options = {
         });
         if (!user) {
           // This is a new user, let's sign them up and authenticate them
-          const newUser = await prisma.user.create({
-            data: {
-              email: credentials.email,
-              hashedPassword: hash(credentials.password),
-            },
-          });
-          return sanitizeUser(newUser);
+          // call createAccount endpoint
+          // const newUser = await prisma.user.create({
+          //   data: {
+          //     email: credentials.email,
+          //     hashedPassword: hashPassword(credentials.password),
+          //   },
+          // });
+          // return sanitizeUser(newUser);
         }
         // Verify that they are specifying a valid invite code
-        if (user.hashedPassword === hash(credentials.password)) {
+        if (user.hashedPassword === hashPassword(credentials.password)) {
           // This is an existing user, let's see if their password matches
           return sanitizeUser(user);
         }

--- a/pages/api/invites/[id].ts
+++ b/pages/api/invites/[id].ts
@@ -13,7 +13,7 @@ const prisma = new PrismaClient();
 export const getInviteById = async (
   id: string
 ): Promise<(UserInvite & { user: SanitizedUser }) | null> => {
-  if (Joi.string().uuid({ version: "uuidv4" }).validate(id)) {
+  if (Joi.string().uuid({ version: "uuidv4" }).validate(id).error) {
     return null;
   }
   const invite = await prisma.userInvite.findOne({

--- a/pages/api/invites/index.ts
+++ b/pages/api/invites/index.ts
@@ -1,0 +1,25 @@
+import { PrismaClient, UserCreateInput } from "@prisma/client";
+import { NextApiRequest, NextApiResponse } from "next";
+
+const prisma = new PrismaClient();
+
+export const createUserWithInvite = async (
+  createOptions: UserCreateInput
+): Promise<void> => {
+  await prisma.user.create({
+    data: {
+      ...createOptions,
+      hashedPassword: "<reset on first login>",
+    },
+  });
+};
+
+const handler = (_: NextApiRequest, res: NextApiResponse): void => {
+  try {
+    // TODO: Add createUserWithInvite logic here
+  } catch (err) {
+    res.status(500).json({ statusCode: 500, message: err.message });
+  }
+};
+
+export default handler;

--- a/pages/api/users/index.ts
+++ b/pages/api/users/index.ts
@@ -27,6 +27,11 @@ type CreateUserDTO = {
 export const createAccount = async (
   user: CreateUserDTO
 ): Promise<SanitizedUser | null> => {
+  if (
+    Joi.string().uuid({ version: "uuidv4" }).validate(user.inviteCodeId).error
+  ) {
+    throw new Error("Invalid inviteCodeId");
+  }
   const loginInfo = {
     name: user.name,
     email: user.email,
@@ -63,8 +68,8 @@ const handler = async (
   try {
     const expectedBody = Joi.object({
       name: Joi.string().required(),
-      email: Joi.string().required(),
-      password: Joi.string().required(),
+      email: Joi.string().email().required(),
+      password: Joi.string().min(8).required(),
       inviteCodeId: Joi.string().optional(),
     });
     const { value, error } = expectedBody.validate(req.body);

--- a/pages/api/users/index.ts
+++ b/pages/api/users/index.ts
@@ -1,13 +1,80 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { sampleUserData } from "utils/sample-data";
+import { PrismaClient } from "@prisma/client";
+import sanitizeUser from "utils/sanitizeUser";
+import hash from "utils/hashPassword";
+import { SanitizedUser } from "interfaces";
+import Joi from "joi";
 
-const handler = (_: NextApiRequest, res: NextApiResponse): void => {
+const prisma = new PrismaClient();
+
+/**
+ * Name
+ * Email
+ */
+type BaseCreateUserDTO = {
+  name: string;
+  email: string;
+};
+
+/**
+ * Password (plaintext)
+ */
+export type UserSignupDTO = BaseCreateUserDTO & {
+  password: string;
+};
+
+/**
+ * Invite code
+ */
+type InviteUserDTO = BaseCreateUserDTO & {
+  inviteCodeId: string;
+};
+
+type CreateUserDTO = UserSignupDTO | InviteUserDTO;
+
+/**
+ * Create an account with email and password (if user signing up) or invite code id (admin signing user up)
+ * @param user - contains metadata
+ */
+
+export const createAccount = async (
+  user: CreateUserDTO
+): Promise<SanitizedUser | null> => {
+  const newUser = await prisma.user.create({
+    data: {
+      email: user.email,
+      hashedPassword:
+        "password" in user ? hash(user.password) : "<created at first login>",
+      // inviteCode: "inviteCodeId" in user ? user.inviteCodeId : "<not given>"
+    },
+  });
+  if (!newUser) {
+    return null;
+  }
+  return sanitizeUser(newUser);
+};
+
+const handler = (req: NextApiRequest, res: NextApiResponse): void => {
+  console.log(req.body, req.method);
   try {
-    if (!Array.isArray(sampleUserData)) {
-      throw new Error("Cannot find user data");
+    const expectedBody = Joi.object({
+      name: Joi.string().required(),
+      email: Joi.string().required(),
+    });
+    const { value, error } = expectedBody.validate(req.body);
+    if (error) {
+      throw new Error(error.message);
     }
+    const body = value as CreateUserDTO;
 
-    res.status(200).json(sampleUserData);
+    const newUser = createAccount(body);
+    if (newUser) {
+      res.status(200).json(newUser);
+    } else {
+      res
+        .status(404)
+        .json({ statusCode: 404, message: "Could not create user" });
+    }
   } catch (err) {
     res.status(500).json({ statusCode: 500, message: err.message });
   }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,7 +64,7 @@ model users {
   image               String?
   created_at          DateTime              @default(now())
   updated_at          DateTime              @default(now())
-  players             players[]
+  players             Player[]
   viewedByPermissions viewing_permissions[] @relation("UsersToViewees")
   viewerPermissions   viewing_permissions[] @relation("UsersToViewers")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,7 +17,7 @@ model User {
   updatedAt      DateTime     @default(now()) @map("updated_at")
   hashedPassword String       @map("hashed_password")
   player         Player?
-  userInvites    UserInvite[] @relation("user_invitesTousers")
+  userInvites    UserInvite[] @relation("UserInvitesToUsers")
 
   @@map("users")
 }
@@ -106,7 +106,7 @@ model UserInvite {
   id         String   @id @default(dbgenerated())
   created_at DateTime @default(now())
   user_id    Int
-  user       User     @relation("user_invitesTousers", fields: [user_id], references: [id])
+  user       User     @relation("UserInvitesToUsers", fields: [user_id], references: [id])
 
   @@map("user_invites")
 }

--- a/utils/hashPassword.ts
+++ b/utils/hashPassword.ts
@@ -1,0 +1,7 @@
+import { createHmac } from "crypto";
+
+const hash = (password: string): string => {
+  return createHmac("sha256", password).digest("hex");
+};
+
+export default hash;


### PR DESCRIPTION
# Finished account creation flow / endpoint
- Account creation (i.e. user signup, with or without invite code)
- Wrote user endpoint and updated authorize call to just check password

(rest of the changes are Ethan's! I was working on his branch)
- Breaks out hashPassword function for generic utility 
- Start of invite creation endpoint
- Bug fix: `getInviteById` should check for error and return null if it exists

CC: @erinysong 