### PR TITLE
User and Viewing Permissions CRUD

### DIFF
--- a/components/schema.sql
+++ b/components/schema.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "public" . "users" (
+    user_id SERIAL PRIMARY KEY NOT NULL,
+    name VARCHAR(255),
+    email VARCHAR(255) UNIQUE NOT NULL,
+    password VARCHAR(255) UNIQUE NOT NULL,
+    roles TEXT, 
+    activated BOOLEAN,
+    is_admin BOOLEAN
+
+);
+
+CREATE TABLE "public" . "Viewing Permissions" (
+    viewee_id INTEGER NULL,
+    viewer_id INTEGER NOT NULL,
+    relationship_type VARCHAR(255)
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,162 @@
+{
+  "name": "ogsc",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
+    },
+    "buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
+      "dev": true
+    },
+    "db-migrate-base": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/db-migrate-base/-/db-migrate-base-2.3.0.tgz",
+      "integrity": "sha512-mxaCkSe7JC2uksvI/rKs+wOQGBSZ6B87xa4b3i+QhB+XRBpGdpMzldKE6INf+EnM6kwhbIPKjyJZgyxui9xBfQ==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.1.1"
+      }
+    },
+    "db-migrate-pg": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/db-migrate-pg/-/db-migrate-pg-1.2.2.tgz",
+      "integrity": "sha512-+rgrhGNWC2SzcfweopyZqOQ1Igz1RVFMUZwUs6SviHpOUzFwb0NZWkG0pw1GaO+JxTxS7VJjckUWkOwZbVYVag==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.1.1",
+        "db-migrate-base": "^2.3.0",
+        "pg": "^8.0.3",
+        "semver": "^5.0.3"
+      }
+    },
+    "packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==",
+      "dev": true
+    },
+    "pg": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.4.1.tgz",
+      "integrity": "sha512-NRsH0aGMXmX1z8Dd0iaPCxWUw4ffu+lIAmGm+sTCwuDDWkpEgRCAHZYDwqaNhC5hG5DRMOjSUFasMWhvcmLN1A==",
+      "dev": true,
+      "requires": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "^2.4.0",
+        "pg-pool": "^3.2.1",
+        "pg-protocol": "^1.3.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      }
+    },
+    "pg-connection-string": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.4.0.tgz",
+      "integrity": "sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ==",
+      "dev": true
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true
+    },
+    "pg-pool": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.2.1.tgz",
+      "integrity": "sha512-BQDPWUeKenVrMMDN9opfns/kZo4lxmSWhIqo+cSAF7+lfi9ZclQbr9vfnlNaPr8wYF3UYjm5X0yPAhbcgqNOdA==",
+      "dev": true
+    },
+    "pg-protocol": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.3.0.tgz",
+      "integrity": "sha512-64/bYByMrhWULUaCd+6/72c9PMWhiVFs3EVxl9Ct6a3v/U8+rKgqP2w+kKg/BIGgMJyB+Bk/eNivT32Al+Jghw==",
+      "dev": true
+    },
+    "pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      }
+    },
+    "pgpass": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
+      "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
+      "dev": true,
+      "requires": {
+        "split": "^1.0.0"
+      }
+    },
+    "postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=",
+      "dev": true
+    },
+    "postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true
+    },
+    "postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "requires": {
+        "xtend": "^4.0.0"
+      }
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
+    },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "requires": {
+        "through": "2"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
+    }
+  }
+}

--- a/pages/api/users/create.ts
+++ b/pages/api/users/create.ts
@@ -1,11 +1,10 @@
-import { PrismaClient, UserInvite } from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
 import { NextApiRequest, NextApiResponse } from "next";
 import Joi from "joi";
 
 const prisma = new PrismaClient();
 
 type UserDTO = {
-  id: number;
   name: string;
   email: string;
   emailVerified: Date;
@@ -13,7 +12,6 @@ type UserDTO = {
   createdAt: Date;
   updatedAt: Date;
   hashedPassword: string;
-  userInvites: UserInvite[];
 };
 
 export default async (
@@ -22,11 +20,10 @@ export default async (
 ): Promise<void> => {
   try {
     const expectedBody = Joi.object({
-      id: Joi.number().required(),
       name: Joi.string().required(),
-      email: Joi.string().required(),
-      email_verified: Joi.date().required(),
-      image: Joi.string().required(),
+      email: Joi.string(),
+      emailVerified: Joi.date(),
+      image: Joi.string(),
       createdAt: Joi.date().required(),
       updatedAt: Joi.date().required(),
       hashedPassword: Joi.string().required(),
@@ -38,7 +35,7 @@ export default async (
     }
     const body = value as UserDTO;
 
-    await prisma.user.create({
+    const user = await prisma.user.create({
       data: {
         name: body.name,
         email: body.email,
@@ -49,7 +46,10 @@ export default async (
         hashedPassword: body.hashedPassword,
       },
     });
-    res.json({ name: "CJ", id: 213 });
+    res.json({
+      message: "Successfully created user.",
+      user,
+    });
   } catch (err) {
     res.status(500);
     res.json({ statusCode: 500, message: err.message });

--- a/pages/api/users/create.ts
+++ b/pages/api/users/create.ts
@@ -33,17 +33,17 @@ export default async (
     if (error) {
       throw new Error(error.message);
     }
-    const body = value as UserDTO;
+    const userInfo = value as UserDTO;
 
     const user = await prisma.user.create({
       data: {
-        name: body.name,
-        email: body.email,
-        emailVerified: body.emailVerified,
-        image: body.image,
-        createdAt: body.createdAt,
-        updatedAt: body.updatedAt,
-        hashedPassword: body.hashedPassword,
+        name: userInfo.name,
+        email: userInfo.email,
+        emailVerified: userInfo.emailVerified,
+        image: userInfo.image,
+        createdAt: userInfo.createdAt,
+        updatedAt: userInfo.updatedAt,
+        hashedPassword: userInfo.hashedPassword,
       },
     });
     res.json({

--- a/pages/api/users/createUser.ts
+++ b/pages/api/users/createUser.ts
@@ -1,4 +1,4 @@
-import { Player, PrismaClient, UserInvite } from "@prisma/client";
+import { PrismaClient, UserInvite } from "@prisma/client";
 import { NextApiRequest, NextApiResponse } from "next";
 import Joi from "joi";
 
@@ -13,10 +13,7 @@ type UserDTO = {
   createdAt: Date;
   updatedAt: Date;
   hashedPassword: string;
-  player: Player;
   userInvites: UserInvite[];
-  viewedByPermissions: ViewingPermission[];
-  viewerPermissions: ViewingPermission[];
 };
 
 export default async (
@@ -32,10 +29,7 @@ export default async (
       image: Joi.string().required(),
       createdAt: Joi.date().required(),
       updatedAt: Joi.date().required(),
-      player: Joi.object().ref(),
       hashedPassword: Joi.string().required(),
-      viewedByPermissions: Joi.array().items(Joi.object()),
-      viewerPermissions: Joi.array().items(Joi.object()),
     });
 
     const { value, error } = expectedBody.validate(req.body);
@@ -53,10 +47,6 @@ export default async (
         createdAt: body.createdAt,
         updatedAt: body.updatedAt,
         hashedPassword: body.hashedPassword,
-        player: body.player,
-        userInvites: body.userInvites,
-        viewedByPermissions: body.viewedByPermissions,
-        viewerPermissions: body.viewerPermissions,
       },
     });
   } catch (err) {

--- a/pages/api/users/createUser.ts
+++ b/pages/api/users/createUser.ts
@@ -49,6 +49,7 @@ export default async (
         hashedPassword: body.hashedPassword,
       },
     });
+    res.json({ name: "CJ", id: 213 });
   } catch (err) {
     res.status(500);
     res.json({ statusCode: 500, message: err.message });

--- a/pages/api/users/createUser.ts
+++ b/pages/api/users/createUser.ts
@@ -1,0 +1,66 @@
+import { Player, PrismaClient, UserInvite } from "@prisma/client";
+import { NextApiRequest, NextApiResponse } from "next";
+import Joi from "joi";
+
+const prisma = new PrismaClient();
+
+type UserDTO = {
+  id: number;
+  name: string;
+  email: string;
+  emailVerified: Date;
+  image: string;
+  createdAt: Date;
+  updatedAt: Date;
+  hashedPassword: string;
+  player: Player;
+  userInvites: UserInvite[];
+  viewedByPermissions: ViewingPermission[];
+  viewerPermissions: ViewingPermission[];
+};
+
+export default async (
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> => {
+  try {
+    const expectedBody = Joi.object({
+      id: Joi.number().required(),
+      name: Joi.string().required(),
+      email: Joi.string().required(),
+      email_verified: Joi.date().required(),
+      image: Joi.string().required(),
+      createdAt: Joi.date().required(),
+      updatedAt: Joi.date().required(),
+      player: Joi.object().ref(),
+      hashedPassword: Joi.string().required(),
+      viewedByPermissions: Joi.array().items(Joi.object()),
+      viewerPermissions: Joi.array().items(Joi.object()),
+    });
+
+    const { value, error } = expectedBody.validate(req.body);
+    if (error) {
+      throw new Error(error.message);
+    }
+    const body = value as UserDTO;
+
+    await prisma.user.create({
+      data: {
+        name: body.name,
+        email: body.email,
+        emailVerified: body.emailVerified,
+        image: body.image,
+        createdAt: body.createdAt,
+        updatedAt: body.updatedAt,
+        hashedPassword: body.hashedPassword,
+        player: body.player,
+        userInvites: body.userInvites,
+        viewedByPermissions: body.viewedByPermissions,
+        viewerPermissions: body.viewerPermissions,
+      },
+    });
+  } catch (err) {
+    res.status(500);
+    res.json({ statusCode: 500, message: err.message });
+  }
+};

--- a/pages/api/users/delete.ts
+++ b/pages/api/users/delete.ts
@@ -32,10 +32,10 @@ export default async (
     if (error) {
       throw new Error(error.message);
     }
-    const body = value as userDTO;
+    const userInfo = value as userDTO;
 
     const user = await prisma.user.delete({
-      where: { id: body.id },
+      where: { id: userInfo.id },
     });
     res.json({
       message: "Successfully deleted user.",

--- a/pages/api/users/delete.ts
+++ b/pages/api/users/delete.ts
@@ -34,8 +34,12 @@ export default async (
     }
     const body = value as userDTO;
 
-    await prisma.user.delete({
+    const user = await prisma.user.delete({
       where: { id: body.id },
+    });
+    res.json({
+      message: "Successfully deleted user.",
+      user,
     });
   } catch (err) {
     res.status(500);

--- a/pages/api/users/delete.ts
+++ b/pages/api/users/delete.ts
@@ -34,16 +34,8 @@ export default async (
     }
     const body = value as userDTO;
 
-    await prisma.user.update({
+    await prisma.user.delete({
       where: { id: body.id },
-      data: {
-        name: body.name,
-        email: body.email,
-        emailVerified: body.emailVerified,
-        image: body.image,
-        createdAt: body.createdAt,
-        updatedAt: body.updatedAt,
-      },
     });
   } catch (err) {
     res.status(500);

--- a/pages/api/users/read.ts
+++ b/pages/api/users/read.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+import { Player, PrismaClient, UserInvite } from "@prisma/client";
 import { NextApiRequest, NextApiResponse } from "next";
 import Joi from "joi";
 
@@ -11,6 +11,8 @@ type userDTO = {
   image: string;
   createdAt: Date;
   updatedAt: Date;
+  player: Player;
+  userInvites: UserInvite[];
 };
 
 export default async (
@@ -26,6 +28,8 @@ export default async (
       image: Joi.string(),
       createdAt: Joi.date(),
       updatedAt: Joi.date(),
+      player: Joi.object().ref(),
+      userInvites: Joi.object(),
     });
 
     const { value, error } = expectedBody.validate(req.body);
@@ -34,17 +38,11 @@ export default async (
     }
     const body = value as userDTO;
 
-    await prisma.user.update({
+    const user = await prisma.user.findOne({
       where: { id: body.id },
-      data: {
-        name: body.name,
-        email: body.email,
-        emailVerified: body.emailVerified,
-        image: body.image,
-        createdAt: body.createdAt,
-        updatedAt: body.updatedAt,
-      },
     });
+
+    res.json(user);
   } catch (err) {
     res.status(500);
     res.json({ statusCode: 500, message: err.message });

--- a/pages/api/users/read.ts
+++ b/pages/api/users/read.ts
@@ -1,18 +1,10 @@
-import { Player, PrismaClient, UserInvite } from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
 import { NextApiRequest, NextApiResponse } from "next";
 import Joi from "joi";
 
 const prisma = new PrismaClient();
 type userDTO = {
   id: number;
-  name: string;
-  email: string;
-  emailVerified: Date;
-  image: string;
-  createdAt: Date;
-  updatedAt: Date;
-  player: Player;
-  userInvites: UserInvite[];
 };
 
 export default async (
@@ -22,14 +14,6 @@ export default async (
   try {
     const expectedBody = Joi.object({
       id: Joi.number().required(),
-      name: Joi.string(),
-      email: Joi.string(),
-      emailVerified: Joi.date(),
-      image: Joi.string(),
-      createdAt: Joi.date(),
-      updatedAt: Joi.date(),
-      player: Joi.object().ref(),
-      userInvites: Joi.object(),
     });
 
     const { value, error } = expectedBody.validate(req.body);

--- a/pages/api/users/read.ts
+++ b/pages/api/users/read.ts
@@ -20,12 +20,17 @@ export default async (
     if (error) {
       throw new Error(error.message);
     }
-    const body = value as userDTO;
+    const userInfo = value as userDTO;
 
     const user = await prisma.user.findOne({
-      where: { id: body.id },
+      where: { id: userInfo.id },
     });
 
+    if (!user) {
+      res
+        .status(404)
+        .json({ statusCode: 404, message: "User does not exist." });
+    }
     res.json(user);
   } catch (err) {
     res.status(500);

--- a/pages/api/users/update.ts
+++ b/pages/api/users/update.ts
@@ -1,0 +1,69 @@
+import {
+  Player,
+  PrismaClient,
+  UserInvite,
+  ViewingPermission,
+} from "@prisma/client";
+import { NextApiRequest, NextApiResponse } from "next";
+import Joi from "joi";
+
+const prisma = new PrismaClient();
+type userDTO = {
+  id: number;
+  name: string;
+  email: string;
+  emailVerified: Date;
+  image: string;
+  createdAt: Date;
+  updatedAt: Date;
+  player: Player;
+  userInvites: UserInvite[];
+  viewedByPermissions: ViewingPermission[];
+  viewerPermissions: ViewingPermission[];
+};
+
+export default async (
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> => {
+  try {
+    const expectedBody = Joi.object({
+      id: Joi.number().required(),
+      name: Joi.string(),
+      email: Joi.string(),
+      emailVerified: Joi.date(),
+      image: Joi.string(),
+      createdAt: Joi.date(),
+      updatedAt: Joi.date(),
+      player: Joi.object().ref(),
+      userInvites: Joi.object(),
+      viewedByPermissions: Joi.array().items(Joi.object()),
+      viewerPermissions: Joi.array().items(Joi.object()),
+    });
+
+    const { value, error } = expectedBody.validate(req.body);
+    if (error) {
+      throw new Error(error.message);
+    }
+    const body = value as userDTO;
+
+    await prisma.user.update({
+      where: { id: body.id },
+      data: {
+        name: body.name,
+        email: body.email,
+        emailVerified: body.emailVerified,
+        image: body.image,
+        createdAt: body.createdAt,
+        updatedAt: body.updatedAt,
+        player: body.player,
+        userInvites: body.userInvites,
+        viewedByPermissions: body.viewedByPermissions,
+        viewerPermissions: body.viewerPermissions,
+      },
+    });
+  } catch (err) {
+    res.status(500);
+    res.json({ statusCode: 500, message: err.message });
+  }
+};

--- a/pages/api/users/update.ts
+++ b/pages/api/users/update.ts
@@ -9,8 +9,7 @@ type userDTO = {
   email: string;
   emailVerified: Date;
   image: string;
-  createdAt: Date;
-  updatedAt: Date;
+  hashedPassword: string;
 };
 
 export default async (
@@ -22,10 +21,8 @@ export default async (
       id: Joi.number().required(),
       name: Joi.string(),
       email: Joi.string(),
-      emailVerified: Joi.date(),
       image: Joi.string(),
-      createdAt: Joi.date(),
-      updatedAt: Joi.date(),
+      hashedPassword: Joi.string(),
     });
 
     const { value, error } = expectedBody.validate(req.body);
@@ -34,16 +31,18 @@ export default async (
     }
     const body = value as userDTO;
 
-    await prisma.user.update({
+    const user = await prisma.user.update({
       where: { id: body.id },
       data: {
         name: body.name,
         email: body.email,
-        emailVerified: body.emailVerified,
         image: body.image,
-        createdAt: body.createdAt,
-        updatedAt: body.updatedAt,
+        hashedPassword: body.hashedPassword,
       },
+    });
+    res.json({
+      message: "Successfully updated user.",
+      user,
     });
   } catch (err) {
     res.status(500);

--- a/pages/api/users/update.ts
+++ b/pages/api/users/update.ts
@@ -29,17 +29,22 @@ export default async (
     if (error) {
       throw new Error(error.message);
     }
-    const body = value as userDTO;
+    const userInfo = value as userDTO;
 
     const user = await prisma.user.update({
-      where: { id: body.id },
+      where: { id: userInfo.id },
       data: {
-        name: body.name,
-        email: body.email,
-        image: body.image,
-        hashedPassword: body.hashedPassword,
+        name: userInfo.name,
+        email: userInfo.email,
+        image: userInfo.image,
+        hashedPassword: userInfo.hashedPassword,
       },
     });
+    if (!user) {
+      res
+        .status(404)
+        .json({ statusCode: 404, message: "User does not exist." });
+    }
     res.json({
       message: "Successfully updated user.",
       user,

--- a/pages/api/viewingPermissions/create.ts
+++ b/pages/api/viewingPermissions/create.ts
@@ -9,33 +9,33 @@ type viewingPermissionDTO = {
   vieweeId: number;
   relationshipType: string;
 };
+const expectedBody = Joi.object({
+  id: Joi.number().required(),
+  viewer_id: Joi.number(),
+  viewee_id: Joi.number(),
+  relationship_type: Joi.string(),
+});
 
 export default async (
   req: NextApiRequest,
   res: NextApiResponse
 ): Promise<void> => {
   try {
-    const expectedBody = Joi.object({
-      id: Joi.number().required(),
-      viewerId: Joi.number(),
-      vieweeId: Joi.number(),
-      relationshipType: Joi.string(),
-    });
-
     const { value, error } = expectedBody.validate(req.body);
     if (error) {
       throw new Error(error.message);
     }
     const body = value as viewingPermissionDTO;
 
-    await prisma.user.create({
+    const view = await prisma.viewingPermission.create({
       data: {
-        id: expectedBody.id,
-        viewerId: body.viewer_id,
-        vieweeId: body.viewee_id,
-        relationshipType: body.relationship_type,
+        id: body.id,
+        viewerId: body.viewerId,
+        vieweeId: body.vieweeId,
+        relationshipType: body.relationshipType,
       },
     });
+    res.json(view);
   } catch (err) {
     res.status(500);
     res.json({ statusCode: 500, message: err.message });

--- a/pages/api/viewingPermissions/create.ts
+++ b/pages/api/viewingPermissions/create.ts
@@ -11,12 +11,12 @@ type viewingPermissionDTO = {
 };
 const expectedBody = Joi.object({
   id: Joi.number().required(),
-  viewer_id: Joi.number(),
-  viewee_id: Joi.number(),
-  relationship_type: Joi.string(),
+  viewer_id: Joi.number().required(),
+  viewee_id: Joi.number().required(),
+  relationship_type: Joi.string().required(),
 });
 
-export default async (
+const handler = async (
   req: NextApiRequest,
   res: NextApiResponse
 ): Promise<void> => {
@@ -30,14 +30,18 @@ export default async (
     const view = await prisma.viewingPermission.create({
       data: {
         id: body.id,
-        viewerId: body.viewerId,
-        vieweeId: body.vieweeId,
-        relationshipType: body.relationshipType,
+        viewer: { connect: { id: body.viewer_id } },
+        viewee: { connect: { id: body.viewee_id } },
+        relationship_type: body.relationship_type,
       },
     });
-    res.json(view);
+    res.json({
+      message: "Successfully created viewing permission.",
+      view,
+    });
   } catch (err) {
     res.status(500);
     res.json({ statusCode: 500, message: err.message });
   }
 };
+export default handler;

--- a/pages/api/viewingPermissions/create.ts
+++ b/pages/api/viewingPermissions/create.ts
@@ -11,9 +11,9 @@ type viewingPermissionDTO = {
 };
 const expectedBody = Joi.object({
   id: Joi.number().required(),
-  viewer_id: Joi.number().required(),
-  viewee_id: Joi.number().required(),
-  relationship_type: Joi.string().required(),
+  viewerId: Joi.number().required(),
+  vieweeId: Joi.number().required(),
+  relationshipType: Joi.string().required(),
 });
 
 const handler = async (
@@ -25,14 +25,14 @@ const handler = async (
     if (error) {
       throw new Error(error.message);
     }
-    const body = value as viewingPermissionDTO;
+    const permissionInfo = value as viewingPermissionDTO;
 
     const view = await prisma.viewingPermission.create({
       data: {
-        id: body.id,
-        viewer: { connect: { id: body.viewer_id } },
-        viewee: { connect: { id: body.viewee_id } },
-        relationship_type: body.relationship_type,
+        id: permissionInfo.id,
+        viewer: { connect: { id: permissionInfo.viewerId } },
+        viewee: { connect: { id: permissionInfo.vieweeId } },
+        relationship_type: permissionInfo.relationshipType,
       },
     });
     res.json({

--- a/pages/api/viewingPermissions/create.ts
+++ b/pages/api/viewingPermissions/create.ts
@@ -3,14 +3,11 @@ import { NextApiRequest, NextApiResponse } from "next";
 import Joi from "joi";
 
 const prisma = new PrismaClient();
-type userDTO = {
+type viewingPermissionDTO = {
   id: number;
-  name: string;
-  email: string;
-  emailVerified: Date;
-  image: string;
-  createdAt: Date;
-  updatedAt: Date;
+  viewerId: number;
+  vieweeId: number;
+  relationshipType: string;
 };
 
 export default async (
@@ -20,29 +17,23 @@ export default async (
   try {
     const expectedBody = Joi.object({
       id: Joi.number().required(),
-      name: Joi.string(),
-      email: Joi.string(),
-      emailVerified: Joi.date(),
-      image: Joi.string(),
-      createdAt: Joi.date(),
-      updatedAt: Joi.date(),
+      viewerId: Joi.number(),
+      vieweeId: Joi.number(),
+      relationshipType: Joi.string(),
     });
 
     const { value, error } = expectedBody.validate(req.body);
     if (error) {
       throw new Error(error.message);
     }
-    const body = value as userDTO;
+    const body = value as viewingPermissionDTO;
 
-    await prisma.user.update({
-      where: { id: body.id },
+    await prisma.user.create({
       data: {
-        name: body.name,
-        email: body.email,
-        emailVerified: body.emailVerified,
-        image: body.image,
-        createdAt: body.createdAt,
-        updatedAt: body.updatedAt,
+        id: expectedBody.id,
+        viewerId: body.viewer_id,
+        vieweeId: body.viewee_id,
+        relationshipType: body.relationship_type,
       },
     });
   } catch (err) {

--- a/pages/api/viewingPermissions/delete.ts
+++ b/pages/api/viewingPermissions/delete.ts
@@ -23,10 +23,10 @@ export default async (
     if (error) {
       throw new Error(error.message);
     }
-    const body = value as viewingPermissionDTO;
+    const permissionInfo = value as viewingPermissionDTO;
 
     const view = await prisma.viewingPermission.delete({
-      where: { id: body.id },
+      where: { id: permissionInfo.id },
     });
     res.json({
       message: "Successfully deleted viewing permission.",

--- a/pages/api/viewingPermissions/delete.ts
+++ b/pages/api/viewingPermissions/delete.ts
@@ -1,0 +1,38 @@
+import { PrismaClient } from "@prisma/client";
+import { NextApiRequest, NextApiResponse } from "next";
+import Joi from "joi";
+
+const prisma = new PrismaClient();
+type viewingPermissionDTO = {
+  id: number;
+  viewerId: number;
+  vieweeId: number;
+  relationshipType: string;
+};
+
+export default async (
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> => {
+  try {
+    const expectedBody = Joi.object({
+      id: Joi.number().required(),
+      viewerId: Joi.number(),
+      vieweeId: Joi.number(),
+      relationshipType: Joi.string(),
+    });
+
+    const { value, error } = expectedBody.validate(req.body);
+    if (error) {
+      throw new Error(error.message);
+    }
+    const body = value as viewingPermissionDTO;
+
+    await prisma.user.delete({
+      where: { id: body.id },
+    });
+  } catch (err) {
+    res.status(500);
+    res.json({ statusCode: 500, message: err.message });
+  }
+};

--- a/pages/api/viewingPermissions/delete.ts
+++ b/pages/api/viewingPermissions/delete.ts
@@ -17,9 +17,6 @@ export default async (
   try {
     const expectedBody = Joi.object({
       id: Joi.number().required(),
-      viewerId: Joi.number(),
-      vieweeId: Joi.number(),
-      relationshipType: Joi.string(),
     });
 
     const { value, error } = expectedBody.validate(req.body);
@@ -28,8 +25,12 @@ export default async (
     }
     const body = value as viewingPermissionDTO;
 
-    await prisma.user.delete({
+    const view = await prisma.viewingPermission.delete({
       where: { id: body.id },
+    });
+    res.json({
+      message: "Successfully deleted viewing permission.",
+      view,
     });
   } catch (err) {
     res.status(500);

--- a/pages/api/viewingPermissions/read.ts
+++ b/pages/api/viewingPermissions/read.ts
@@ -27,12 +27,17 @@ export default async (
     if (error) {
       throw new Error(error.message);
     }
-    const body = value as viewingPermissionDTO;
+    const permissionInfo = value as viewingPermissionDTO;
 
     const view = await prisma.viewingPermission.findOne({
-      where: { id: body.id },
+      where: { id: permissionInfo.id },
     });
-
+    if (!view) {
+      res.status(404).json({
+        statusCode: 404,
+        message: "Viewing Permission does not exist.",
+      });
+    }
     res.json(view);
   } catch (err) {
     res.status(500);

--- a/pages/api/viewingPermissions/read.ts
+++ b/pages/api/viewingPermissions/read.ts
@@ -29,11 +29,11 @@ export default async (
     }
     const body = value as viewingPermissionDTO;
 
-    const viewingPermission = await prisma.viewingPermission.findOne({
+    const view = await prisma.viewingPermission.findOne({
       where: { id: body.id },
     });
 
-    res.json(viewingPermission);
+    res.json(view);
   } catch (err) {
     res.status(500);
     res.json({ statusCode: 500, message: err.message });

--- a/pages/api/viewingPermissions/read.ts
+++ b/pages/api/viewingPermissions/read.ts
@@ -3,14 +3,12 @@ import { NextApiRequest, NextApiResponse } from "next";
 import Joi from "joi";
 
 const prisma = new PrismaClient();
-type userDTO = {
+
+type viewingPermissionDTO = {
   id: number;
-  name: string;
-  email: string;
-  emailVerified: Date;
-  image: string;
-  createdAt: Date;
-  updatedAt: Date;
+  viewerId: number;
+  vieweeId: number;
+  relationshipType: string;
 };
 
 export default async (
@@ -20,31 +18,22 @@ export default async (
   try {
     const expectedBody = Joi.object({
       id: Joi.number().required(),
-      name: Joi.string(),
-      email: Joi.string(),
-      emailVerified: Joi.date(),
-      image: Joi.string(),
-      createdAt: Joi.date(),
-      updatedAt: Joi.date(),
+      viewerId: Joi.number(),
+      vieweeId: Joi.number(),
+      relationshipType: Joi.string(),
     });
 
     const { value, error } = expectedBody.validate(req.body);
     if (error) {
       throw new Error(error.message);
     }
-    const body = value as userDTO;
+    const body = value as viewingPermissionDTO;
 
-    await prisma.user.update({
+    const viewingPermission = await prisma.viewingPermission.findOne({
       where: { id: body.id },
-      data: {
-        name: body.name,
-        email: body.email,
-        emailVerified: body.emailVerified,
-        image: body.image,
-        createdAt: body.createdAt,
-        updatedAt: body.updatedAt,
-      },
     });
+
+    res.json(viewingPermission);
   } catch (err) {
     res.status(500);
     res.json({ statusCode: 500, message: err.message });


### PR DESCRIPTION
# CRUD Endpoints for Users and Viewing Permissions

Added CRUD functionality for the users and viewing permission tables! Side note: Viewing Permissions do not have the update functionality as per our discussions on Thursday

Link to Postman workspace: https://app.getpostman.com/join-team?invite_code=cfbf914cf9a9d1ae51fb29227f98860b&ws=96e23380-723e-4345-a916-f2ccdfe54700

## Related PRs

@sydbui just an update that Users CRUD functions work now :)

## Migrations

Did not add anything to the database. However wanted to bring up that the unique ID for the viewing permissions schema is currently not auto incremented and will probably need to be changed in the future. 

## Screenshots of Postman Tests

Create User
<img width="575" alt="image" src="https://user-images.githubusercontent.com/65790318/96335278-7146c180-102c-11eb-9c77-124d157e5d5d.png">


Read User
<img width="732" alt="image" src="https://user-images.githubusercontent.com/65790318/96335306-a4895080-102c-11eb-8b5a-7910224b3d0c.png">


Update User
<img width="621" alt="image" src="https://user-images.githubusercontent.com/65790318/96335323-c2ef4c00-102c-11eb-922b-aba6111599b8.png">


Delete User
<img width="636" alt="image" src="https://user-images.githubusercontent.com/65790318/96335346-e1554780-102c-11eb-9a03-1e9cb785d4b5.png">



Create Viewing Permission
<img width="715" alt="image" src="https://user-images.githubusercontent.com/65790318/96335362-ff22ac80-102c-11eb-9000-073512f5de39.png">


Read Viewing Permission
<img width="649" alt="image" src="https://user-images.githubusercontent.com/65790318/96335372-0cd83200-102d-11eb-8cdd-9820395397df.png">


Delete Viewing Permission
<img width="733" alt="image" src="https://user-images.githubusercontent.com/65790318/96335393-25484c80-102d-11eb-86f1-bfee3ecea6b9.png">

_Required for visual changes_

CC: @erinysong @shannonmhong 
