### PR TITLE
Player profile navbar outline

### DIFF
--- a/pages/playerProfile.tsx
+++ b/pages/playerProfile.tsx
@@ -30,6 +30,7 @@ const PlayerNavBar: React.FunctionComponent = () => {
         {Button("Highlights")}
       </div>
       <div className="mt-12 mb-10 text-xl">{title}</div>
+      {/* TODO: add profile content to each tab */}
     </div>
   );
 };

--- a/pages/playerprofile.tsx
+++ b/pages/playerprofile.tsx
@@ -1,16 +1,55 @@
-const PlayerProfile: React.FunctionComponent = () => (
-  // add a padding to this box
-  <div className="flex ">
-    <div className="header flex">
-      {/* image */}
-      <image className="rounded-full h-16 w-16 flex items-center justify-center bg-gray-400">
-        a
-      </image>
-      {/* player name */}
-      {/* player number?? */}
+import { useState } from "react";
+
+const PlayerNavBar: React.FunctionComponent = () => {
+  const [title, setTitle] = useState("Overview");
+  const Button = (category: string): unknown => {
+    return (
+      <button
+        type="button"
+        className={
+          title === category
+            ? "bg-gray-300 py-3 px-8 rounded-full"
+            : "py-3 px-8 rounded-full"
+        }
+        onClick={() => {
+          setTitle(category);
+        }}
+      >
+        {category}
+      </button>
+    );
+  };
+  return (
+    <div>
+      <div className="flex flex-row justify-between text-xs text-center">
+        {Button("Overview")}
+        {Button("Engagement")}
+        {Button("Academic Performance")}
+        {Button("Attendance")}
+        {Button("Physical Wellness")}
+        {Button("Highlights")}
+      </div>
+      <div className="mt-12 mb-10 text-xl">{title}</div>
     </div>
-    {/* grid with buttons and each button will change the info shown on the screen */}
-    {/* title of each section */}
+  );
+};
+
+const PlayerProfile: React.FunctionComponent = () => (
+  <div className="flex mt-20 flex-wrap space-y-6 flex-col mx-16">
+    <div className="header flex">
+      <div className="picture flex mr-10">
+        <img
+          src="/reference to pic"
+          alt="..."
+          className="shadow rounded-full max-w-full align-middle border-none w-24 h-24"
+        />
+      </div>
+      <div className="player-info grid grid-rows-2">
+        <p className="pt-6 text-xl">Player Name</p>
+        <p className="pt-2 text-xs">Player Number</p>
+      </div>
+    </div>
+    {PlayerNavBar({})}
   </div>
 );
 

--- a/pages/playerprofile.tsx
+++ b/pages/playerprofile.tsx
@@ -1,0 +1,17 @@
+const PlayerProfile: React.FunctionComponent = () => (
+  // add a padding to this box
+  <div className="flex ">
+    <div className="header flex">
+      {/* image */}
+      <image className="rounded-full h-16 w-16 flex items-center justify-center bg-gray-400">
+        a
+      </image>
+      {/* player name */}
+      {/* player number?? */}
+    </div>
+    {/* grid with buttons and each button will change the info shown on the screen */}
+    {/* title of each section */}
+  </div>
+);
+
+export default PlayerProfile;


### PR DESCRIPTION
# Player Profile Navbar 
(first draft, no props being passed in)
- Worked with @sydbui to create a first draft of the player profile page (above the section title)
- Followed dimensions on [Player Profile Figma](https://www.figma.com/file/OXSYtCJxra1NzMT7I58HVx/OGSC?node-id=58%3A9) as closely as possibly in accordance with [Tailwind's spacing options](https://tailwindcss.com/docs/customizing-spacing)



## Related PRs

@shannonmhong you might be able to take some of this for Admin Dashboard Navbar!

## Screenshots
Player profile with _Overview tab_ selected
<img width="1435" alt="Screen Shot 2020-10-22 at 11 29 38 PM" src="https://user-images.githubusercontent.com/34170094/96964544-80f85700-14bf-11eb-8ef6-24229af27154.png">

CC: @erinysong
