### PR TITLE
Seed script updates: admin user, mentors + viewing permissions

### DIFF
--- a/bin/seed-database.ts
+++ b/bin/seed-database.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { PrismaClient, UserCreateArgs } from "@prisma/client";
+import { PrismaClient, User, UserCreateArgs } from "@prisma/client";
 import Faker from "faker";
 import Ora from "ora";
 import hashPassword from "../utils/hashPassword";
@@ -8,10 +8,56 @@ const NUMBER_USERS = 10;
 
 export default async function seedDatabase(): Promise<void> {
   const prisma = new PrismaClient();
+  const clearAllMessage = Ora("Cleaning up previous seeded information");
+  try {
+    const users = await prisma.user.findMany({
+      where: {
+        email: {
+          endsWith: "@ogsc.dev",
+        },
+      },
+    });
+    await prisma.player.deleteMany({
+      where: {
+        user_id: {
+          in: users.map((user: User) => user.id),
+        },
+      },
+    });
+    await prisma.user.deleteMany({
+      where: {
+        email: {
+          endsWith: "@ogsc.dev",
+        },
+      },
+    });
+    clearAllMessage.text = "Cleaned up previous seeded information";
+    clearAllMessage.succeed();
+  } catch (err) {
+    clearAllMessage.fail(
+      `Could not clean up previous seeded information\n\n${err.message}`
+    );
+    process.exit(1);
+  }
+
+  const adminCreateMessage = Ora(`Creating admin user`).start();
+  try {
+    await prisma.user.create({
+      data: {
+        name: "Admin User",
+        email: "admin@ogsc.dev",
+        hashedPassword: hashPassword("password"),
+        isAdmin: true,
+      },
+    });
+    adminCreateMessage.text = "Created the admin user.";
+    adminCreateMessage.succeed();
+  } catch (err) {
+    adminCreateMessage.fail(`Creating the admin user failed\n\n${err.message}`);
+  }
 
   const usersCreateMessage = Ora(`Creating ${NUMBER_USERS} players`).start();
-
-  const mockUsers: UserCreateArgs[] = Array(NUMBER_USERS)
+  const mockPlayers: UserCreateArgs[] = Array(NUMBER_USERS)
     .fill(null)
     .map((_value: null, index: number) => {
       return {
@@ -50,13 +96,42 @@ export default async function seedDatabase(): Promise<void> {
       };
     });
   try {
-    await Promise.all(mockUsers.map(prisma.user.create));
+    await Promise.all(mockPlayers.map(prisma.user.create));
+    usersCreateMessage.text = "Created 10 players.";
+    usersCreateMessage.succeed();
   } catch (err) {
-    usersCreateMessage.fail(`Creating users failed\n\n${err.message}`);
-    process.exit(1);
+    usersCreateMessage.fail(`Creating players failed\n\n${err.message}`);
   }
-  usersCreateMessage.text = "Created 10 players.";
-  usersCreateMessage.succeed();
+
+  const mentorsCreateMessage = Ora(`Creating ${NUMBER_USERS} mentors`).start();
+  const mockMentors: UserCreateArgs[] = Array(NUMBER_USERS)
+    .fill(null)
+    .map((_value: null, index: number) => {
+      return {
+        data: {
+          email: `mentor${index}@ogsc.dev`,
+          hashedPassword: hashPassword("password"),
+          name: `${Faker.name.firstName()} ${Faker.name.lastName()}`,
+          viewerPermissions: {
+            create: {
+              viewee: {
+                connect: {
+                  email: `player${index}@ogsc.dev`,
+                },
+              },
+            },
+          },
+        },
+      };
+    });
+  try {
+    await Promise.all(mockMentors.map(prisma.user.create));
+    mentorsCreateMessage.text = "Created 10 mentors.";
+    mentorsCreateMessage.succeed();
+  } catch (err) {
+    mentorsCreateMessage.fail(`Creating mentors failed\n\n${err.message}`);
+  }
+
   process.exit(0);
 }
 

--- a/migrations/20201025034105-UseSerialIdsForViewingPermissions.ts
+++ b/migrations/20201025034105-UseSerialIdsForViewingPermissions.ts
@@ -1,0 +1,47 @@
+import Base from "db-migrate-base";
+
+/**
+ * Add autoincrement sequence behavior to the IDs of the viewing_permissions table.
+ */
+export async function up(
+  db: Base,
+  callback: Base.CallbackFunction
+): Promise<void> {
+  db.runSql(
+    `
+  CREATE SEQUENCE viewing_permissions_id_seq
+    INCREMENT 1
+    START 1
+    MINVALUE 1
+    MAXVALUE 2147483647
+    CACHE 1;
+    
+  ALTER TABLE viewing_permissions ALTER id SET DEFAULT nextval('viewing_permissions_id_seq'::regclass);
+    `,
+    callback
+  );
+}
+
+/**
+ * Remove autoincrement sequence behavior to the IDs of the viewing_permissions table.
+ *
+ * **Note**: This is not a safe down migration as the ID sequence will be destroyed and recreated
+ * with a start value of 1.
+ */
+export async function down(
+  db: Base,
+  callback: Base.CallbackFunction
+): Promise<void> {
+  db.runSql(
+    `
+  DROP SEQUENCE viewing_permissions_id_seq;
+  ALTER TABLE viewing_permissions ALTER id DROP DEFAULT;
+    `,
+    callback
+  );
+}
+
+// eslint-disable-next-line no-underscore-dangle
+export const _meta = {
+  version: 1,
+};

--- a/migrations/20201025034105-UseSerialIdsForViewingPermissions.ts
+++ b/migrations/20201025034105-UseSerialIdsForViewingPermissions.ts
@@ -9,7 +9,7 @@ export async function up(
 ): Promise<void> {
   db.runSql(
     `
-  CREATE SEQUENCE viewing_permissions_id_seq
+  CREATE SEQUENCE IF NOT EXISTS viewing_permissions_id_seq
     INCREMENT 1
     START 1
     MINVALUE 1
@@ -24,9 +24,6 @@ export async function up(
 
 /**
  * Remove autoincrement sequence behavior to the IDs of the viewing_permissions table.
- *
- * **Note**: This is not a safe down migration as the ID sequence will be destroyed and recreated
- * with a start value of 1.
  */
 export async function down(
   db: Base,
@@ -34,7 +31,6 @@ export async function down(
 ): Promise<void> {
   db.runSql(
     `
-  DROP SEQUENCE viewing_permissions_id_seq;
   ALTER TABLE viewing_permissions ALTER id DROP DEFAULT;
     `,
     callback

--- a/pages/api/admin/viewingPermissions/create.ts
+++ b/pages/api/admin/viewingPermissions/create.ts
@@ -15,7 +15,6 @@ type ViewingPermissionDTO = {
 };
 
 const expectedBody = Joi.object<ViewingPermissionDTO>({
-  id: Joi.number().required(),
   viewerId: Joi.number().required(),
   vieweeId: Joi.number().required(),
   relationshipType: Joi.string().required(),
@@ -29,7 +28,6 @@ const handler = async (
     const permissionInfo = req.body;
     const view = await prisma.viewingPermission.create({
       data: {
-        id: permissionInfo.id,
         viewer: { connect: { id: permissionInfo.viewerId } },
         viewee: { connect: { id: permissionInfo.vieweeId } },
         relationship_type: permissionInfo.relationshipType,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -103,7 +103,7 @@ model UserInvite {
 }
 
 model ViewingPermission {
-  id                Int     @id
+  id                Int     @id @default(autoincrement())
   viewer_id         Int?
   viewee_id         Int?
   relationship_type String?


### PR DESCRIPTION
Addresses future work specified in #19.

* Adds cleanup step to remove all @ogsc.dev users before seeding the database
* Adds admin-type user (admin@ogsc.dev)
* Adds mentor-type users (mentor[0-9]@ogsc.dev), connected to their corresponding player-type users (player[0-9]@ogsc.dev).

## PR Checklist

Does your branch (check if true):

- [x] work when you run `yarn build`?
- [x] successfully run `yarn db:migrate up` without yielding any errors?
- [x] successfully run `yarn prisma introspect` without yielding any errors or adding any new uncommitted changes?
- [x] successfully run `yarn dev` and support all changes that your branch intends to perform?

## Migrations

* Adds a migration to add an ID sequence for the viewing_permissions table. This is required for Prisma to recognize that the ID does not need to be supplied on creation.

CC: @erinysong
