### PR TITLE
Add admin "invite new user" page

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "css.validate": false
 }

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -5,7 +5,8 @@ type Props = React.PropsWithChildren<{
   iconType?: IconType;
   onClick?: React.MouseEventHandler;
   pill?: boolean;
-}>;
+}> &
+  React.HTMLAttributes<HTMLButtonElement>;
 
 const Button: React.FC<Props> = ({
   children,
@@ -13,7 +14,8 @@ const Button: React.FC<Props> = ({
   iconType,
   onClick,
   pill,
-}) => {
+  ...additionalButtonProps
+}: Props) => {
   return (
     <button
       className={`button button-normal ${
@@ -21,6 +23,7 @@ const Button: React.FC<Props> = ({
       } ${className}`}
       onClick={onClick}
       type="button"
+      {...additionalButtonProps}
     >
       {iconType && (
         <Icon

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -16,7 +16,7 @@ const Button: React.FC<Props> = ({
 }) => {
   return (
     <button
-      className={`bg-button flex items-center px-6 py-3 font-medium ${
+      className={`button button-normal ${
         pill ? "rounded-full" : "rounded"
       } ${className}`}
       onClick={onClick}

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -5,6 +5,7 @@ type Props = React.PropsWithChildren<{
   iconType?: IconType;
   onClick?: React.MouseEventHandler;
   pill?: boolean;
+  type?: "button" | "submit" | "reset";
 }> &
   React.HTMLAttributes<HTMLButtonElement>;
 
@@ -14,6 +15,7 @@ const Button: React.FC<Props> = ({
   iconType,
   onClick,
   pill,
+  type = "button",
   ...additionalButtonProps
 }: Props) => {
   return (
@@ -22,7 +24,8 @@ const Button: React.FC<Props> = ({
         pill ? "rounded-full" : "rounded"
       } ${className}`}
       onClick={onClick}
-      type="button"
+      // eslint-disable-next-line react/button-has-type
+      type={type}
       {...additionalButtonProps}
     >
       {iconType && (

--- a/components/DashboardLayout/Sidebar.tsx
+++ b/components/DashboardLayout/Sidebar.tsx
@@ -44,6 +44,7 @@ const SidebarsByRole: Record<UserRole, React.ReactNode> = {
       <SidebarLink href="/mentor/notes">Notes</SidebarLink>
     </>
   ),
+  parent: <></>,
   player: (
     <>
       <SidebarLink href="/player/profile">Profile</SidebarLink>

--- a/components/DashboardLayout/Sidebar.tsx
+++ b/components/DashboardLayout/Sidebar.tsx
@@ -18,7 +18,7 @@ const SidebarLink: React.FC<SidebarLinkProps> = ({
     <Link href={href} passHref>
       <a
         className={`block mb-8 font-medium ${
-          router.pathname !== href ? "text-unselected" : ""
+          !router.pathname.startsWith(href) ? "text-unselected" : ""
         }`}
       >
         {children}

--- a/components/FormField.tsx
+++ b/components/FormField.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+type Props = React.PropsWithChildren<{
+  label: string;
+  name: string;
+}>;
+
+const FormField: React.FC<Props> = ({ children, label, name }: Props) => {
+  return (
+    <label className="font-medium block mb-8" htmlFor={name}>
+      <p className="mb-3">{label}</p>
+      {children}
+    </label>
+  );
+};
+
+export default FormField;

--- a/components/FormField.tsx
+++ b/components/FormField.tsx
@@ -3,13 +3,20 @@ import React from "react";
 type Props = React.PropsWithChildren<{
   label: string;
   name: string;
+  error?: string;
 }>;
 
-const FormField: React.FC<Props> = ({ children, label, name }: Props) => {
+const FormField: React.FC<Props> = ({
+  children,
+  error,
+  label,
+  name,
+}: Props) => {
   return (
     <label className="font-medium block mb-8" htmlFor={name}>
       <p className="mb-3">{label}</p>
       {children}
+      {error && <p className="text-red-600 text-sm mt-1">{error}</p>}
     </label>
   );
 };

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+type Props = React.PropsWithChildren<{
+  open?: boolean;
+}>;
+
+const Modal: React.FC<Props> = ({ children, open }: Props) => {
+  return open ? (
+    <div className="absolute top-0 left-0 w-screen h-screen bg-dark bg-opacity-50 flex justify-center items-center">
+      <div className="bg-white rounded w-1/2 px-10 pt-12 pb-8">{children}</div>
+    </div>
+  ) : null;
+};
+
+export default Modal;

--- a/interfaces/index.ts
+++ b/interfaces/index.ts
@@ -22,11 +22,18 @@ export type ValidatedNextApiHandler<T, R = unknown> = (
   ...args: unknown[]
 ) => void | Promise<void>;
 
-export const UserRoleConstants = <const>["admin", "mentor", "player", "donor"];
+export const UserRoleConstants = <const>[
+  "admin",
+  "mentor",
+  "parent",
+  "player",
+  "donor",
+];
 export type UserRole = typeof UserRoleConstants[number];
 export const UserRoleLabel: Record<UserRole, string> = {
   admin: "Admin",
   mentor: "Mentor",
+  parent: "Parent",
   player: "Player",
   donor: "Donor",
 };

--- a/migrations/20201028050959-AddPhoneNumberToUsers.ts
+++ b/migrations/20201028050959-AddPhoneNumberToUsers.ts
@@ -1,0 +1,33 @@
+import Base from "db-migrate-base";
+
+/**
+ * Add phone number column to users.
+ */
+export async function up(
+  db: Base,
+  callback: Base.CallbackFunction
+): Promise<void> {
+  db.addColumn(
+    "users",
+    "phone_number",
+    {
+      type: "string",
+    },
+    callback
+  );
+}
+
+/**
+ * Drop phone number column from users.
+ */
+export async function down(
+  db: Base,
+  callback: Base.CallbackFunction
+): Promise<void> {
+  db.removeColumn("users", "phone_number", callback);
+}
+
+// eslint-disable-next-line no-underscore-dangle
+export const _meta = {
+  version: 1,
+};

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     }
   },
   "dependencies": {
+    "@hookform/resolvers": "^1.0.0",
     "@prisma/client": "2.8.0",
     "autoprefixer": "9.8.6",
     "db-migrate": "^0.11.11",
@@ -35,6 +36,7 @@
     "postcss-import": "^12.0.1",
     "react": "16.13.1",
     "react-dom": "16.13.1",
+    "react-hook-form": "^6.9.6",
     "tailwindcss": "^1.9.4"
   },
   "devDependencies": {

--- a/pages/admin/invite/index.tsx
+++ b/pages/admin/invite/index.tsx
@@ -1,9 +1,13 @@
 import Button from "components/Button";
 import DashboardLayout from "components/DashboardLayout";
+import Modal from "components/Modal";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import React from "react";
 
 const AdminInvitePage: React.FC = () => {
+  const router = useRouter();
+
   return (
     <DashboardLayout>
       <div className="mx-16 mt-24">
@@ -14,6 +18,22 @@ const AdminInvitePage: React.FC = () => {
           <Button iconType="plus">Create a new user</Button>
         </Link>
       </div>
+      <Modal open={Boolean(router.query.success)}>
+        <h1 className="text-dark text-3xl font-medium mb-2">Invite Sent!</h1>
+        <p className="text-dark mb-10">
+          Your invitee will have ? days to accept their invite.
+        </p>
+        <div className="flex justify-end">
+          <Button
+            className="button-primary px-10 py-3"
+            onClick={() => {
+              router.replace("/admin/invite");
+            }}
+          >
+            Done
+          </Button>
+        </div>
+      </Modal>
     </DashboardLayout>
   );
 };

--- a/pages/admin/invite/index.tsx
+++ b/pages/admin/invite/index.tsx
@@ -1,5 +1,6 @@
 import Button from "components/Button";
 import DashboardLayout from "components/DashboardLayout";
+import Link from "next/link";
 import React from "react";
 
 const AdminInvitePage: React.FC = () => {
@@ -9,7 +10,9 @@ const AdminInvitePage: React.FC = () => {
         <h1 className="text-3xl font-display font-medium mb-10">
           Invite Users
         </h1>
-        <Button iconType="plus">Create a new user</Button>
+        <Link href="/admin/invite/new">
+          <Button iconType="plus">Create a new user</Button>
+        </Link>
       </div>
     </DashboardLayout>
   );

--- a/pages/admin/invite/new.tsx
+++ b/pages/admin/invite/new.tsx
@@ -55,6 +55,7 @@ const AdminNewInvitePage: React.FC = () => {
                     className="mr-3"
                     type="radio"
                     name="role"
+                    id={role}
                     value={role}
                   />
                   {UserRoleLabel[role]}

--- a/pages/admin/invite/new.tsx
+++ b/pages/admin/invite/new.tsx
@@ -1,11 +1,76 @@
+import { joiResolver } from "@hookform/resolvers/joi";
 import Button from "components/Button";
 import DashboardLayout from "components/DashboardLayout";
 import FormField from "components/FormField";
 import { UserRole, UserRoleConstants, UserRoleLabel } from "interfaces";
+import Joi from "joi";
 import Link from "next/link";
-import React from "react";
+import { useRouter } from "next/router";
+import { AdminCreateUserDTO } from "pages/api/admin/users/create";
+import React, { useState } from "react";
+import { useForm } from "react-hook-form";
+
+type AdminInviteFormValues = {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phoneNumber?: string;
+  role: UserRole;
+};
+
+const AdminInviteFormSchema = Joi.object<AdminInviteFormValues>({
+  firstName: Joi.string().trim().required(),
+  lastName: Joi.string().trim().required(),
+  email: Joi.string()
+    .trim()
+    .email({ tlds: { allow: false } })
+    .required(),
+  phoneNumber: Joi.string().optional(),
+  role: Joi.string()
+    .valid(...UserRoleConstants)
+    .required(),
+});
 
 const AdminNewInvitePage: React.FC = () => {
+  const router = useRouter();
+
+  // TODO: Add loading state to form submission
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+  const { errors, register, handleSubmit } = useForm<AdminInviteFormValues>({
+    resolver: joiResolver(AdminInviteFormSchema),
+  });
+
+  async function onSubmit(
+    values: AdminInviteFormValues,
+    event?: React.BaseSyntheticEvent
+  ): Promise<void> {
+    event?.preventDefault();
+    if (submitting) {
+      return;
+    }
+    try {
+      const response = await fetch("/api/admin/users", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({
+          email: values.email,
+          name: `${values.firstName} ${values.lastName}`,
+          phoneNumber: values.phoneNumber,
+        } as AdminCreateUserDTO),
+      });
+      if (!response.ok) {
+        throw await response.json();
+      }
+      router.push("/admin/invite?success=true", "/admin/invite");
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
   return (
     <DashboardLayout>
       <div className="mx-16 mt-24">
@@ -13,42 +78,62 @@ const AdminNewInvitePage: React.FC = () => {
           Add a new user
         </h1>
         <p>Pending page description</p>
-        <form className="mt-10">
+        <form className="mt-10" onSubmit={handleSubmit(onSubmit)}>
           <fieldset>
             <legend className="text-lg font-medium mb-8">User Overview</legend>
-            <FormField label="First Name" name="firstName">
+            <FormField
+              label="First Name"
+              name="firstName"
+              error={errors.firstName?.message}
+            >
               <input
                 type="text"
                 className="input input-full"
                 name="firstName"
                 placeholder="e.g., Cristiano"
+                ref={register}
               />
             </FormField>
-            <FormField label="Last Name" name="lastName">
+            <FormField
+              label="Last Name"
+              name="lastName"
+              error={errors.lastName?.message}
+            >
               <input
                 type="text"
                 className="input input-full"
                 name="lastName"
                 placeholder="e.g., Ronaldo"
+                ref={register}
               />
             </FormField>
-            <FormField label="Email Address" name="email">
+            <FormField
+              label="Email Address"
+              name="email"
+              error={errors.email?.message}
+            >
               <input
                 type="text"
                 className="input input-full"
                 name="email"
                 placeholder="e.g., soccer@fifa.com"
+                ref={register}
               />
             </FormField>
-            <FormField label="Phone Number" name="phoneNumber">
+            <FormField
+              label="Phone Number"
+              name="phoneNumber"
+              error={errors.phoneNumber?.message}
+            >
               <input
                 type="text"
                 className="input"
                 name="phoneNumber"
                 placeholder="e.g., 123-456-7890"
+                ref={register}
               />
             </FormField>
-            <FormField label="Role" name="role">
+            <FormField label="Role" name="role" error={errors.role?.message}>
               {UserRoleConstants.map((role: UserRole) => (
                 <label className="block font-normal" htmlFor={role}>
                   <input
@@ -57,6 +142,7 @@ const AdminNewInvitePage: React.FC = () => {
                     name="role"
                     id={role}
                     value={role}
+                    ref={register}
                   />
                   {UserRoleLabel[role]}
                 </label>
@@ -64,13 +150,16 @@ const AdminNewInvitePage: React.FC = () => {
             </FormField>
           </fieldset>
           <hr />
-          <div className="my-10 flex">
-            <Button className="button-primary px-10 py-2 mr-5">
-              Send Invite
-            </Button>
-            <Link href="/admin/invite">
-              <Button className="button-hollow px-10 py-2">Cancel</Button>
-            </Link>
+          <div className="my-10">
+            <div className="mb-2 flex">
+              <Button className="button-primary px-10 py-2 mr-5" type="submit">
+                Send Invite
+              </Button>
+              <Link href="/admin/invite">
+                <Button className="button-hollow px-10 py-2">Cancel</Button>
+              </Link>
+            </div>
+            {error && <p className="text-red-600 text-sm">{error}</p>}
           </div>
         </form>
       </div>

--- a/pages/admin/invite/new.tsx
+++ b/pages/admin/invite/new.tsx
@@ -1,0 +1,80 @@
+import Button from "components/Button";
+import DashboardLayout from "components/DashboardLayout";
+import FormField from "components/FormField";
+import { UserRole, UserRoleConstants, UserRoleLabel } from "interfaces";
+import Link from "next/link";
+import React from "react";
+
+const AdminNewInvitePage: React.FC = () => {
+  return (
+    <DashboardLayout>
+      <div className="mx-16 mt-24">
+        <h1 className="text-3xl font-display font-medium mb-2">
+          Add a new user
+        </h1>
+        <p>Pending page description</p>
+        <form className="mt-10">
+          <fieldset>
+            <legend className="text-lg font-medium mb-8">User Overview</legend>
+            <FormField label="First Name" name="firstName">
+              <input
+                type="text"
+                className="input input-full"
+                name="firstName"
+                placeholder="e.g., Cristiano"
+              />
+            </FormField>
+            <FormField label="Last Name" name="lastName">
+              <input
+                type="text"
+                className="input input-full"
+                name="lastName"
+                placeholder="e.g., Ronaldo"
+              />
+            </FormField>
+            <FormField label="Email Address" name="email">
+              <input
+                type="text"
+                className="input input-full"
+                name="email"
+                placeholder="e.g., soccer@fifa.com"
+              />
+            </FormField>
+            <FormField label="Phone Number" name="phoneNumber">
+              <input
+                type="text"
+                className="input"
+                name="phoneNumber"
+                placeholder="e.g., 123-456-7890"
+              />
+            </FormField>
+            <FormField label="Role" name="role">
+              {UserRoleConstants.map((role: UserRole) => (
+                <label className="block font-normal" htmlFor={role}>
+                  <input
+                    className="mr-3"
+                    type="radio"
+                    name="role"
+                    value={role}
+                  />
+                  {UserRoleLabel[role]}
+                </label>
+              ))}
+            </FormField>
+          </fieldset>
+          <hr />
+          <div className="my-10 flex">
+            <Button className="button-primary px-10 py-2 mr-5">
+              Send Invite
+            </Button>
+            <Link href="/admin/invite">
+              <Button className="button-hollow px-10 py-2">Cancel</Button>
+            </Link>
+          </div>
+        </form>
+      </div>
+    </DashboardLayout>
+  );
+};
+
+export default AdminNewInvitePage;

--- a/pages/api/admin/users/create.ts
+++ b/pages/api/admin/users/create.ts
@@ -11,7 +11,10 @@ import { adminOnlyHandler } from "../helpers";
 
 const prisma = new PrismaClient();
 
-type AdminCreateUserDTO = Pick<CreateUserDTO, "email" | "name">;
+export type AdminCreateUserDTO = Pick<
+  CreateUserDTO,
+  "email" | "name" | "phoneNumber"
+>;
 const AdminCreateUserDTOValidator = CreateUserDTOValidator.keys({
   password: Joi.forbidden(),
   inviteCodeId: Joi.forbidden(),
@@ -21,12 +24,13 @@ const handler = async (
   req: ValidatedNextApiRequest<AdminCreateUserDTO>,
   res: NextApiResponse
 ): Promise<void> => {
-  const { email, name } = req.body;
+  const { email, name, phoneNumber } = req.body;
   try {
     const newUser = await prisma.user.create({
       data: {
         name,
         email,
+        phoneNumber,
         hashedPassword: "<set on first login>",
         userInvites: {
           create: {},

--- a/pages/api/users/index.ts
+++ b/pages/api/users/index.ts
@@ -9,16 +9,6 @@ import { getInviteById } from "../invites/[id]";
 
 const prisma = new PrismaClient();
 
-export type UserDTO = {
-  name: string;
-  email: string;
-  emailVerified: Date;
-  image: string;
-  createdAt: Date;
-  updatedAt: Date;
-  password: string;
-};
-
 /**
  * All users signing up
  */
@@ -26,6 +16,7 @@ export type CreateUserDTO = {
   name: string;
   email: string;
   password: string;
+  phoneNumber?: string;
   inviteCodeId?: string;
 };
 
@@ -33,6 +24,7 @@ export const CreateUserDTOValidator = Joi.object<CreateUserDTO>({
   name: Joi.string().required(),
   email: Joi.string().email().required(),
   password: Joi.string().min(8).required(),
+  phoneNumber: Joi.string().optional(),
   inviteCodeId: Joi.string().optional(),
 });
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,7 @@ model User {
   updatedAt           DateTime            @default(now()) @map("updated_at")
   hashedPassword      String              @map("hashed_password")
   isAdmin             Boolean             @default(false) @map("is_admin")
+  phoneNumber         String?             @map("phone_number")
   player              Player?
   resetPassword       ResetPassword[]     @relation("ResetPasswordToUsers")
   userInvites         UserInvite[]        @relation("UserInvitesToUsers")

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -25,3 +25,39 @@ a {
   font-weight: normal;
   font-style: normal;
 }
+
+@layer components {
+  .button {
+    @apply flex items-center px-6 py-3 font-medium;
+  }
+
+  .button-normal {
+    @apply bg-button;
+  }
+
+  .button-primary {
+    @apply bg-unselected text-white;
+  }
+
+  .button-hollow {
+    @apply bg-transparent border-unselected border-2 text-unselected;
+  }
+
+  .input {
+    @apply border-unselected border-b-2 px-2 py-1;
+  }
+
+  .input:focus {
+    @apply border-dark outline-none bg-button;
+  }
+
+  .input-full {
+    @apply w-full max-w-lg;
+  }
+
+  @screen lg {
+    .input-full {
+      @apply w-1/2;
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1075,6 +1075,11 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
+"@hookform/resolvers@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-1.0.0.tgz#ad924cb846343fe0a42addcf0b055c4f9aa2dcb9"
+  integrity sha512-YzBq6ZFw/uWGa3rXBNSHqnsE4hDXLrzdboDxPRKGjYHVzs1dBxjvELftP8iTmRPqP32VjnbVfUktX1CQ6Y7sog==
+
 "@next/react-dev-overlay@9.5.3":
   version "9.5.3"
   resolved "https://registry.yarnpkg.com/@next/react-dev-overlay/-/react-dev-overlay-9.5.3.tgz#3275301f08045ecc709e3273031973a1f5e81427"
@@ -5999,6 +6004,11 @@ react-dom@16.13.1:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.19.1"
+
+react-hook-form@^6.9.6:
+  version "6.9.6"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.9.6.tgz#bbcdfa34a660edcdd160cba2d501583b0e3d60a9"
+  integrity sha512-TyLqWHgFS1WLELDuUBvMWLHEzmR7aS7xOY+eOxMtS1w4jFhqF1xmHnMhJsbiFPSgC+OeTJ1Pc0U4K0y6cA7ERA==
 
 react-is@16.13.1, react-is@^16.8.1:
   version "16.13.1"


### PR DESCRIPTION
* Adds /admin/new invite page form
* Creates new components for styling: FormField (to automatically set up a label and error messaging element around the input) and Modal
* Adds react-hook-form + @hookform/joi at the suggestion of @joyydong, for tracking stateful values and validations in the form
* Adds migration and schema update for storing phone numbers of users

**Future work:**
* Validate and standardize phone number inputs with libphonenumber or similar
* Roles should present role-specific questions, whose answers should influence part of the API request payload to POST /api/admin/invites

## PR Checklist

Does your branch (check if true):
- [x] work when you run `yarn build`?
- [x] successfully run `yarn:db-migrate up` without yielding any errors?
- [x] successfully run `yarn prisma introspect` without yielding any errors?
- [x] successfully run `yarn dev` and support all changes that your branch intends to perform?

## Migrations

* 95f4031 introduces `20201028050959-AddPhoneNumberToUsers`, which adds an optional string-type `phone_number` column to the users table.

## Screenshots

![image](https://user-images.githubusercontent.com/2977329/97404439-550c1580-18b3-11eb-9262-d8ec43ee7913.png)
![image](https://user-images.githubusercontent.com/2977329/97407267-acac8000-18b7-11eb-81ee-dc43d09afc52.png)


CC: @erinysong
