### PR TITLE
Create absences table with schema/seed updates

### DIFF
--- a/bin/seed-database.ts
+++ b/bin/seed-database.ts
@@ -1,5 +1,7 @@
 /* eslint-disable no-console */
 import {
+  Absence,
+  AbsenceCreateWithoutUsersInput,
   PrismaClient,
   ProfileFieldCreateWithoutUserInput,
   ProfileFieldKey,
@@ -8,6 +10,7 @@ import {
 } from "@prisma/client";
 import Faker from "faker";
 import Ora from "ora";
+import { AbsenceReason, AbsenceType } from "../interfaces";
 import hashPassword from "../utils/hashPassword";
 
 const NUMBER_USERS = 10;
@@ -96,6 +99,23 @@ export default async function seedDatabase(): Promise<void> {
           email: `player${index}@ogsc.dev`,
           hashedPassword: hashPassword("password"),
           name: `${Faker.name.firstName()} ${Faker.name.lastName()}`,
+          absences: {
+            create: Object.values(AbsenceType).flatMap((type: AbsenceType) =>
+              Array<Absence | null>(Faker.random.number(3))
+                .fill(null)
+                .map(
+                  () =>
+                    <AbsenceCreateWithoutUsersInput>{
+                      type,
+                      date: Faker.date.recent(90),
+                      reason: Faker.random.arrayElement(
+                        Object.values(AbsenceReason)
+                      ),
+                      description: Faker.lorem.lines(1),
+                    }
+                )
+            ),
+          },
           profileFields: {
             create: [
               ...generateFieldsAcrossTimestamps(

--- a/interfaces/user.ts
+++ b/interfaces/user.ts
@@ -1,4 +1,4 @@
-import { ProfileField, User, ViewingPermission } from "@prisma/client";
+import { Absence, ProfileField, User, ViewingPermission } from "@prisma/client";
 
 // TODO: Use Prisma-generated types for this once prisma/prisma#3252 is resolved
 export const ProfileFieldKey = <const>{
@@ -24,6 +24,21 @@ export const ProfileFieldKey = <const>{
   Situps: "Situps",
 };
 export type ProfileFieldKey = typeof ProfileFieldKey[keyof typeof ProfileFieldKey];
+
+// TODO: Use Prisma-generated types for this once prisma/prisma#3252 is resolved
+export const AbsenceReason = <const>{
+  Excused: "Excused",
+  Unexcused: "Unexcused",
+};
+export type AbsenceReason = typeof AbsenceReason[keyof typeof AbsenceReason];
+
+// TODO: Use Prisma-generated types for this once prisma/prisma#3252 is resolved
+export const AbsenceType = <const>{
+  School: "School",
+  Academic: "Academic",
+  Athletic: "Athletic",
+};
+export type AbsenceType = typeof AbsenceType[keyof typeof AbsenceType];
 
 export type PrivateUserFields = "hashedPassword";
 export type SanitizedUser = Omit<User, PrivateUserFields>;
@@ -95,5 +110,6 @@ export type PlayerProfile = {
 
 export type IUser = SanitizedUser & {
   profile: PlayerProfile | null;
+  absences: Absence[];
   viewerPermissions: ViewingPermission[];
 };

--- a/migrations/20201108050951-CreateAbsencesTable.ts
+++ b/migrations/20201108050951-CreateAbsencesTable.ts
@@ -1,0 +1,85 @@
+import Base from "db-migrate-base";
+import { promisify } from "util";
+
+/**
+ * Create a table for tracking player absences.
+ */
+export async function up(
+  db: Base,
+  callback: Base.CallbackFunction
+): Promise<void> {
+  const runSql = promisify(db.runSql.bind(db));
+  const createTable = promisify(db.createTable.bind(db));
+
+  try {
+    await runSql(
+      `CREATE TYPE absence_reason AS ENUM (
+        'excused',
+        'unexcused'
+      );`,
+      []
+    );
+    await createTable("absences", {
+      id: {
+        type: "int",
+        primaryKey: true,
+        autoIncrement: true,
+        notNull: true,
+        unsigned: true,
+      },
+      user_id: {
+        type: "int",
+        unsigned: true,
+        notNull: true,
+        foreignKey: {
+          name: "fk_absences_user_id",
+          table: "users",
+          rules: {
+            onDelete: "CASCADE",
+            onUpdate: "RESTRICT",
+          },
+          mapping: "id",
+        },
+      },
+      date: {
+        type: "datetime",
+        notNull: true,
+      },
+      description: {
+        type: "text",
+        defaultValue: "",
+        notNull: true,
+      },
+      reason: {
+        type: "absence_reason",
+        notNull: true,
+      },
+    });
+    db.addIndex("absences", "idx_absences_user_id", ["user_id"], callback);
+  } catch (err) {
+    callback(err, null);
+  }
+}
+
+/**
+ * Drop the absences able.
+ */
+export async function down(
+  db: Base,
+  callback: Base.CallbackFunction
+): Promise<void> {
+  const removeIndex = promisify(db.removeIndex.bind(db));
+  const dropTable = promisify<string>(db.dropTable.bind(db));
+  try {
+    await removeIndex("absences", "idx_absences_user_id");
+    await dropTable("absences");
+    db.runSql("DROP TYPE IF EXISTS absence_reason", callback);
+  } catch (err) {
+    callback(err, null);
+  }
+}
+
+// eslint-disable-next-line no-underscore-dangle
+export const _meta = {
+  version: 1,
+};

--- a/migrations/20201108050951-CreateAbsencesTable.ts
+++ b/migrations/20201108050951-CreateAbsencesTable.ts
@@ -19,6 +19,14 @@ export async function up(
       );`,
       []
     );
+    await runSql(
+      `CREATE TYPE absence_type AS ENUM (
+        'school',
+        'academic',
+        'athletic'
+      );`,
+      []
+    );
     await createTable("absences", {
       id: {
         type: "int",
@@ -50,6 +58,10 @@ export async function up(
         defaultValue: "",
         notNull: true,
       },
+      type: {
+        type: "absence_type",
+        notNull: true,
+      },
       reason: {
         type: "absence_reason",
         notNull: true,
@@ -70,9 +82,12 @@ export async function down(
 ): Promise<void> {
   const removeIndex = promisify(db.removeIndex.bind(db));
   const dropTable = promisify<string>(db.dropTable.bind(db));
+  const runSql = promisify(db.runSql.bind(db));
+
   try {
     await removeIndex("absences", "idx_absences_user_id");
     await dropTable("absences");
+    await runSql("DROP TYPE IF EXISTS absence_type", []);
     db.runSql("DROP TYPE IF EXISTS absence_reason", callback);
   } catch (err) {
     callback(err, null);

--- a/pages/api/users/me.ts
+++ b/pages/api/users/me.ts
@@ -19,6 +19,7 @@ export default routeByMethod({
     const user = await prisma.user.findOne({
       where: { email: session.user.email },
       include: {
+        absences: true,
         profileFields: true,
         viewerPermissions: true,
       },

--- a/pages/player/[id].tsx
+++ b/pages/player/[id].tsx
@@ -1,4 +1,4 @@
-import { PrismaClient, ProfileField, User } from "@prisma/client";
+import { Absence, PrismaClient, ProfileField, User } from "@prisma/client";
 import DashboardLayout from "components/DashboardLayout";
 import PlayerProfile from "components/Player/Profile";
 import { NextPageContext } from "next";
@@ -6,7 +6,10 @@ import sanitizeUser from "utils/sanitizeUser";
 import buildUserProfile from "utils/buildUserProfile";
 
 type Props = {
-  player?: Omit<User & { profileFields: ProfileField[] }, "hashedPassword">;
+  player?: Omit<
+    User & { absences: Absence[]; profileFields: ProfileField[] },
+    "hashedPassword"
+  >;
 };
 
 export async function getServerSideProps(
@@ -16,7 +19,7 @@ export async function getServerSideProps(
   const id = context.query.id as string;
   const user = await prisma.user.findOne({
     where: { id: Number(id) },
-    include: { profileFields: true, viewerPermissions: true },
+    include: { absences: true, profileFields: true, viewerPermissions: true },
   });
 
   if (user === null) {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -120,6 +120,7 @@ model Absence {
   userId      Int           @map("user_id")
   date        DateTime
   description String        @default("")
+  type        AbsenceType
   reason      AbsenceReason
   users       User          @relation("AbsencesToUsers", fields: [userId], references: [id])
 
@@ -157,4 +158,12 @@ enum AbsenceReason {
   Unexcused @map("unexcused")
 
    @@map("absence_reason")
+}
+
+enum AbsenceType {
+  Academic @map("academic")
+  Athletic @map("athletic")
+  School @map("school")
+
+   @@map("absence_type")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,7 @@ model User {
   hashedPassword      String              @map("hashed_password")
   isAdmin             Boolean             @default(false) @map("is_admin")
   phoneNumber         String?             @map("phone_number")
+  absences            Absence[]           @relation("AbsencesToUsers")
   profileFields       ProfileField[]      @relation("ProfileFieldToUsers")
   resetPassword       ResetPassword[]     @relation("ResetPasswordToUsers")
   userInvites         UserInvite[]        @relation("UserInvitesToUsers")
@@ -114,6 +115,18 @@ model ProfileField {
   @@map("profile_fields")
 }
 
+model Absence {
+  id          Int           @id @default(autoincrement())
+  userId      Int           @map("user_id")
+  date        DateTime
+  description String        @default("")
+  reason      AbsenceReason
+  users       User          @relation("AbsencesToUsers", fields: [userId], references: [id])
+
+  @@index([userId], name: "idx_absences_user_id")
+  @@map("absences")
+}
+
 enum ProfileFieldKey {
   AcademicEngagementScore @map("academic_engagement_score")
   AdvisingScore @map("advising_score")
@@ -137,4 +150,11 @@ enum ProfileFieldKey {
   Situps @map("situps")
 
    @@map("profile_field_key")
+}
+
+enum AbsenceReason {
+  Excused @map("excused")
+  Unexcused @map("unexcused")
+
+   @@map("absence_reason")
 }


### PR DESCRIPTION
* Create absences table linked to users
* Updates Prisma schema and DB seeding script to reflect absences updates
  * The seed script will add 0-3 absences for every type (school, academic, athletic) for random reasons

## How to Test/Use PR feature

* Run `yarn db:migrate up` and `yarn db:seed`. Verify that the migration and seed succeeds without error.

## PR Checklist

Does your branch (check if true):
- [x] work when you run `yarn build`?
- [x] successfully run `yarn:db-migrate up` without yielding any errors?
- [x] successfully run `yarn prisma introspect` without yielding any errors?
- [x] successfully run `yarn dev` and support all changes that your branch intends to perform?

## Migrations

* `20201108050951-CreateAbsencesTable`: Creates absences table

CC: @erinysong
