### PR TITLE
Add Sendgrid notifier for staging/prod uses

### DIFF
--- a/lib/notify/index.ts
+++ b/lib/notify/index.ts
@@ -1,8 +1,10 @@
 import DevelopmentConsoleNotifier from "./development";
+import SendgridNotifier from "./sendgrid";
 import { Notifier } from "./types";
 
-// TODO: Add additional logic here to select the right notifier
-const notifier: Notifier = new DevelopmentConsoleNotifier();
+const notifier: Notifier = process.env.SENDGRID_API_KEY
+  ? new SendgridNotifier()
+  : new DevelopmentConsoleNotifier();
 
 async function setupNotifier(): Promise<void> {
   try {

--- a/lib/notify/sendgrid.ts
+++ b/lib/notify/sendgrid.ts
@@ -1,0 +1,39 @@
+import sendgrid from "@sendgrid/mail";
+import {
+  NotificationMeta,
+  NotificationResult,
+  NotificationType,
+  Notifier,
+} from "./types";
+
+export default class SendgridNotifier implements Notifier {
+  id = "SENDGRID";
+
+  templates: Record<NotificationType, string> = {
+    [NotificationType.ForgotPassword]: "d-9e3ecf30ca4846a68e1e879db5105974",
+    [NotificationType.SignUpInvitation]: "d-3ad525e2c11840e59dce1a51d1d89004",
+  };
+
+  async setup(): Promise<void> {
+    if (!process.env.SENDGRID_API_KEY) {
+      throw new Error(
+        "SENDGRID_API_KEY environment variable required to setup the SendgridNotifier"
+      );
+    }
+    sendgrid.setApiKey(process.env.SENDGRID_API_KEY);
+  }
+
+  async sendNotification<T extends NotificationType>(
+    type: T,
+    meta: NotificationMeta[T]
+  ): Promise<NotificationResult> {
+    await sendgrid.send({
+      to: meta.email,
+      from: "ogsc@calblueprint.org",
+      templateId: this.templates[type],
+      dynamicTemplateData: meta,
+    });
+
+    return { ok: true };
+  }
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@hookform/resolvers": "^1.0.0",
     "@prisma/client": "2.8.0",
+    "@sendgrid/mail": "^7.4.0",
     "autoprefixer": "9.8.6",
     "db-migrate": "^0.11.11",
     "db-migrate-base": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1139,6 +1139,29 @@
   dependencies:
     pkg-up "^3.1.0"
 
+"@sendgrid/client@^7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@sendgrid/client/-/client-7.4.0.tgz#07c26936f88ade43fb845ce00b37d882999c0a04"
+  integrity sha512-KAZlEb1P8sATgBN+7hXgzaRF94nF9KQgDxQ6zUT1BV0kEsNtJQ2cs35sCtWt6AKKJrL0xPI/MsfcAJqom4YQBg==
+  dependencies:
+    "@sendgrid/helpers" "^7.4.0"
+    axios "^0.19.2"
+
+"@sendgrid/helpers@^7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@sendgrid/helpers/-/helpers-7.4.0.tgz#be98730c89c190c8873e2f25d868a13d26b75b25"
+  integrity sha512-IQI2vemiJB0+X6bEp4HRG+0/wrzR2RDGnB5rwfq1CsPDrUFdJfxbE2zbGx//1GnlNwAtbHyc93ejU1m0KZr86w==
+  dependencies:
+    deepmerge "^4.2.2"
+
+"@sendgrid/mail@^7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@sendgrid/mail/-/mail-7.4.0.tgz#126de0f0fc7c62d5d609140261fd598b6291fee3"
+  integrity sha512-SAARsfbl50OEJ99LYGKfgrYiV5O6+23aeGJuEBTHHSwRZ6KhD3n1BjPeIejbqgbqYLZJfNLxyU3o5xRdJPp3zg==
+  dependencies:
+    "@sendgrid/client" "^7.4.0"
+    "@sendgrid/helpers" "^7.4.0"
+
 "@sqltools/formatter@1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@sqltools/formatter/-/formatter-1.2.2.tgz#9390a8127c0dcba61ebd7fdcc748655e191bdd68"
@@ -1790,6 +1813,13 @@ axe-core@^3.5.4:
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.5.tgz#84315073b53fa3c0c51676c588d59da09a192227"
   integrity sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==
+
+axios@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
 
 axobject-query@^2.1.2:
   version "2.2.0"
@@ -2767,6 +2797,13 @@ debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "2.1.2"
 
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
 decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -2796,6 +2833,11 @@ deep-is@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
 
 defaults@^1.0.3:
   version "1.0.3"
@@ -3637,6 +3679,13 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
* Adds new Notifier implementation that uses Sendgrid's email API
* Adds `@sendgrid/mail` as a dependency. You'll need to run yarn after pulling these changes.

## How to Test/Use PR feature

* Add `SENDGRID_API_KEY` to your .env file (lib/notify will detect if this is present and opt to use the Sendgrid notifier over the development notifier if so) — I've added a staging API key [here (internal).](https://calblueprint.slack.com/archives/G01B26QJ10T/p1604819331041000)
* Visit http://localhost:3000/admin/invite as an admin and invite a user with your email. Submit the form.
* Verify that you receive a signup invitation email.

## PR Checklist

Does your branch (check if true):
- [x] work when you run `yarn build`?
- [x] successfully run `yarn:db-migrate up` without yielding any errors?
- [x] successfully run `yarn prisma introspect` without yielding any errors?
- [x] successfully run `yarn dev` and support all changes that your branch intends to perform?

CC: @erinysong
