### PR TITLE
Engagement score graphs and tables

### DIFF
--- a/bin/seed-database.ts
+++ b/bin/seed-database.ts
@@ -19,18 +19,27 @@ function generateFieldsAcrossTimestamps(
   key: ProfileFieldKey,
   generateValue: () => unknown
 ): ProfileFieldCreateWithoutUserInput[] {
-  return [
-    new Date("2020-10-01T12:00:00+00:00"),
-    new Date("2020-10-15T12:00:00+00:00"),
-    new Date("2020-10-30T12:00:00+00:00"),
-  ].map(
-    (date: Date) =>
-      <ProfileFieldCreateWithoutUserInput>{
-        key,
-        value: String(generateValue()),
-        createdAt: date,
-      }
-  );
+  return Array(12)
+    .fill(null)
+    .map(
+      (_, index: number) =>
+        new Date(
+          `2020-${String(index + 1).padStart(2, "0")}-${String(
+            Faker.random.number({
+              min: 1,
+              max: 28,
+            })
+          ).padStart(2, "0")}T12:00:00+00:00`
+        )
+    )
+    .map(
+      (date: Date) =>
+        <ProfileFieldCreateWithoutUserInput>{
+          key,
+          value: String(generateValue()),
+          createdAt: date,
+        }
+    );
 }
 
 export default async function seedDatabase(): Promise<void> {

--- a/components/Player/PlayerFormLayout/ProgressBar.tsx
+++ b/components/Player/PlayerFormLayout/ProgressBar.tsx
@@ -18,7 +18,7 @@ const BarTab: React.FunctionComponent<BarProps> = ({
         <div
           className={
             fill
-              ? "bg-darkBlue h-2 rounded-full"
+              ? "bg-blue h-2 rounded-full"
               : "bg-placeholder h-2 rounded-full"
           }
         />

--- a/components/Player/Profile.tsx
+++ b/components/Player/Profile.tsx
@@ -2,9 +2,9 @@ import React, { useContext, useState } from "react";
 import Icon, { IconType } from "components/Icon";
 import { AbsenceType, IPlayer, ProfileFieldKey } from "interfaces";
 import formatDate from "utils/formatDate";
-import ScoreBox from "./ScoreBox";
 import TextLayout from "./TextLayout";
 import AbsenceTable from "./AbsenceTable";
+import ValueHistoryView from "./ValueHistoryView";
 
 enum ProfileCategory {
   Overview = "Overview",
@@ -77,6 +77,9 @@ const ProfileFieldLabels: Partial<Record<ProfileFieldKey, string>> = {
   [ProfileFieldKey.MileTime]: "1 Mile Time",
   [ProfileFieldKey.Situps]: "Sit-Ups",
   [ProfileFieldKey.Pushups]: "Push-Ups",
+  [ProfileFieldKey.AcademicEngagementScore]: "School Engagement",
+  [ProfileFieldKey.AdvisingScore]: "Academic Advising Engagement",
+  [ProfileFieldKey.AthleticScore]: "Athletics Engagement",
 };
 
 const PlayerContext = React.createContext<IPlayer | null>(null);
@@ -96,31 +99,37 @@ const ProfileContentCell: React.FC<ProfileContentCellProps> = ({
   switch (profileField.key) {
     case ProfileFieldKey.AcademicEngagementScore:
       return (
-        <ScoreBox
-          score={profileField.current}
-          lastUpdated={profileField.lastUpdated}
+        <ValueHistoryView
           icon="school"
-          title="School"
+          primaryColor="pink"
+          fieldLabel={
+            ProfileFieldLabels.AcademicEngagementScore || "Engagement"
+          }
+          shortFieldLabel="Engagement"
+          values={profileField.history}
         />
       );
     case ProfileFieldKey.AdvisingScore:
       return (
-        <ScoreBox
-          score={profileField.current}
-          lastUpdated={profileField.lastUpdated}
+        <ValueHistoryView
           icon="academics"
-          title="Academic Advising"
+          primaryColor="gold"
+          fieldLabel={ProfileFieldLabels.AdvisingScore || "Engagement"}
+          shortFieldLabel="Engagement"
+          values={profileField.history}
         />
       );
     case ProfileFieldKey.AthleticScore:
       return (
-        <ScoreBox
-          score={profileField.current}
-          lastUpdated={profileField.lastUpdated}
+        <ValueHistoryView
           icon="athletics"
-          title="Athletic"
+          primaryColor="blue"
+          fieldLabel={ProfileFieldLabels.AthleticScore || "Engagement"}
+          shortFieldLabel="Engagement"
+          values={profileField.history}
         />
       );
+
     case ProfileFieldKey.BMI:
       return (
         <>
@@ -194,11 +203,15 @@ const ProfileContents = <T extends ProfileCategory>({
       return (
         <div>
           <h1 className="mb-10 text-2xl font-semibold">Engagement</h1>
-          <div className="grid grid-cols-3 gap-24 justify-items-stretch h-56">
+          <div className="mb-16">
             <ProfileContentCell
               fieldKey={ProfileFieldKey.AcademicEngagementScore}
             />
+          </div>
+          <div className="mb-16">
             <ProfileContentCell fieldKey={ProfileFieldKey.AdvisingScore} />
+          </div>
+          <div className="mb-16">
             <ProfileContentCell fieldKey={ProfileFieldKey.AthleticScore} />
           </div>
         </div>

--- a/components/Player/Profile.tsx
+++ b/components/Player/Profile.tsx
@@ -1,7 +1,6 @@
 import React, { useContext, useState } from "react";
 import Icon, { IconType } from "components/Icon";
 import { AbsenceType, IPlayer, ProfileFieldKey } from "interfaces";
-import formatDate from "utils/formatDate";
 import TextLayout from "./TextLayout";
 import AbsenceTable from "./AbsenceTable";
 import ValueHistoryView from "./ValueHistoryView";
@@ -80,6 +79,7 @@ const ProfileFieldLabels: Partial<Record<ProfileFieldKey, string>> = {
   [ProfileFieldKey.AcademicEngagementScore]: "School Engagement",
   [ProfileFieldKey.AdvisingScore]: "Academic Advising Engagement",
   [ProfileFieldKey.AthleticScore]: "Athletics Engagement",
+  [ProfileFieldKey.GPA]: "Grade Point Average",
 };
 
 const PlayerContext = React.createContext<IPlayer | null>(null);
@@ -107,6 +107,7 @@ const ProfileContentCell: React.FC<ProfileContentCellProps> = ({
           }
           shortFieldLabel="Engagement"
           values={profileField.history}
+          valueLabel="point"
         />
       );
     case ProfileFieldKey.AdvisingScore:
@@ -117,16 +118,18 @@ const ProfileContentCell: React.FC<ProfileContentCellProps> = ({
           fieldLabel={ProfileFieldLabels.AdvisingScore || "Engagement"}
           shortFieldLabel="Engagement"
           values={profileField.history}
+          valueLabel="point"
         />
       );
     case ProfileFieldKey.AthleticScore:
       return (
         <ValueHistoryView
           icon="athletics"
-          primaryColor="blue"
+          primaryColor="purple"
           fieldLabel={ProfileFieldLabels.AthleticScore || "Engagement"}
           shortFieldLabel="Engagement"
           values={profileField.history}
+          valueLabel="point"
         />
       );
 
@@ -148,12 +151,14 @@ const ProfileContentCell: React.FC<ProfileContentCellProps> = ({
       );
     case ProfileFieldKey.GPA:
       return (
-        <>
-          <TextLayout title="GPA">{profileField.current.toFixed(2)}</TextLayout>
-          <div className="mb-5 text-sm font-light">
-            Last Updated {formatDate(profileField.lastUpdated)}
-          </div>
-        </>
+        <ValueHistoryView
+          icon="book"
+          primaryColor="blue"
+          fieldLabel={ProfileFieldLabels.GPA || "GPA"}
+          shortFieldLabel="GPA"
+          values={profileField.history}
+          valueRange={[2, 4]}
+        />
       );
     case ProfileFieldKey.HealthAndWellness:
       return (
@@ -220,7 +225,6 @@ const ProfileContents = <T extends ProfileCategory>({
       return (
         <div>
           <h1 className="mb-10 text-2xl font-semibold">Academic Performance</h1>
-          <div className="mb-6 text-lg font-semibold">Grade Point Average</div>
           <ProfileContentCell fieldKey={ProfileFieldKey.GPA} />
           <ProfileContentCell fieldKey={ProfileFieldKey.DisciplinaryActions} />
         </div>

--- a/components/Player/ValueHistoryView.tsx
+++ b/components/Player/ValueHistoryView.tsx
@@ -326,26 +326,53 @@ const ValueHistoryView: React.FC<Props> = ({
               data={deserializedValues.map((datum) => ({
                 x: datum.createdAt,
                 y: datum.value,
-                label: `${datum.value} points`,
+                label: [
+                  datum.createdAt.toLocaleDateString("default", {
+                    month: "short",
+                    year: "numeric",
+                  }),
+                  datum.value === 1
+                    ? `${datum.value} point`
+                    : `${datum.value} points`,
+                ],
               }))}
               labelComponent={
                 <VictoryTooltip
                   labelComponent={
                     <VictoryLabel
-                      style={{
-                        fill: "#FFFFFF",
-                        fontFamily: "Montserrat",
-                        fontSize: "8px",
-                        fontWeight: 600,
-                      }}
+                      lineHeight={[1.5, 1]}
+                      style={[
+                        {
+                          fill: "#FFFFFF",
+                          fontFamily: "Montserrat",
+                          fontSize: "6px",
+                          fontWeight: 500,
+                          opacity: 0.8,
+                        },
+                        {
+                          fill: "#FFFFFF",
+                          fontFamily: "Montserrat",
+                          fontSize: "8px",
+                          fontWeight: 600,
+                        },
+                      ]}
                     />
                   }
                   flyoutStyle={{
                     fill: colors.palette[primaryColor],
                     strokeWidth: 0,
                   }}
+                  cornerRadius={3}
+                  flyoutPadding={{
+                    top: -3,
+                    bottom: -3,
+                    left: 5,
+                    right: -5,
+                  }}
                   pointerLength={5}
+                  pointerWidth={6}
                   dy={-8}
+                  style={{ textAnchor: "start" }}
                 />
               }
             >

--- a/components/Player/ValueHistoryView.tsx
+++ b/components/Player/ValueHistoryView.tsx
@@ -60,7 +60,7 @@ const ValueHistoryView: React.FC<Props> = ({
   primaryColor,
   values,
 }: Props) => {
-  const [historyView, setHistoryView] = useState<"graph" | "table">("table");
+  const [historyView, setHistoryView] = useState<"graph" | "table">("graph");
 
   const deserializedValues = values.map(
     (field: IProfileField<NumericProfileFields>) => ({
@@ -183,7 +183,7 @@ const ValueHistoryView: React.FC<Props> = ({
           </svg>
           <VictoryChart
             containerComponent={
-              <VictoryVoronoiContainer className="-mt-8" voronoiDimension="x" />
+              <VictoryVoronoiContainer voronoiDimension="x" />
             }
             theme={{
               ...VictoryTheme.grayscale,
@@ -316,7 +316,8 @@ const ValueHistoryView: React.FC<Props> = ({
                   data: {
                     stroke: ({ active }) =>
                       active ? colors.palette[primaryColor] : "transparent",
-                    strokeDasharray: "5, 5",
+                    strokeDasharray: "6, 4",
+                    strokeWidth: 1.5,
                   },
                 }}
                 data={[

--- a/components/Player/ValueHistoryView.tsx
+++ b/components/Player/ValueHistoryView.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useState } from "react";
 import { ProfileField } from "@prisma/client";
+import Button from "components/Button";
 import Icon, { IconType } from "components/Icon";
 import {
   IProfileField,
@@ -47,6 +48,8 @@ const ValueHistoryView: React.FC<Props> = ({
   primaryColor,
   values,
 }: Props) => {
+  const [historyView, setHistoryView] = useState<"graph" | "table">("table");
+
   const averageValue =
     values.reduce(
       (total: number, field: ProfileField) =>
@@ -91,7 +94,59 @@ const ValueHistoryView: React.FC<Props> = ({
             <option>Last 6 Months</option>
           </select>
         </div>
+        <div className="flex">
+          <Button
+            className={`bg-transparent navigation-tab rounded-full border-none py-2 mr-2 leading-7 ${
+              historyView === "graph"
+                ? `bg-${primaryColor}-muted text-${primaryColor} font-semibold`
+                : ""
+            }`}
+            onClick={() => setHistoryView("graph")}
+          >
+            Graph
+          </Button>
+          <Button
+            className={`bg-transparent navigation-tab rounded-full border-none py-2 leading-7 ${
+              historyView === "table"
+                ? `bg-${primaryColor}-muted text-${primaryColor} font-semibold`
+                : ""
+            }`}
+            onClick={() => setHistoryView("table")}
+          >
+            Table
+          </Button>
+        </div>
       </div>
+      {historyView === "table" && (
+        <table className="w-full mt-4">
+          <thead>
+            <tr className="h-10 text-left text-unselected tr-border">
+              <th className="w-3/12 pl-5 font-semibold">Date</th>
+              <th className="w-3/12 font-semibold">Score</th>
+              <th className="font-semibold">Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {values.map((field: IProfileField<NumericProfileFields>) => (
+              <tr key={field.id} className="h-16 tr-border">
+                <td className="w-3/12 pl-5">
+                  {new Date(field.createdAt).toLocaleString("default", {
+                    month: "short",
+                    year: "numeric",
+                  })}
+                </td>
+                <td className="w-3/12">
+                  {deserializeProfileFieldValue<
+                    ProfileField,
+                    NumericProfileFields
+                  >(field)}
+                </td>
+                <td />
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 };

--- a/components/Player/ValueHistoryView.tsx
+++ b/components/Player/ValueHistoryView.tsx
@@ -52,6 +52,17 @@ type Props = {
   primaryColor: keyof typeof colors.palette;
 
   values: IProfileField<NumericProfileFields>[];
+
+  /**
+   * Specify the range of possible valules as [minimum, maximum].
+   */
+  valueRange?: [number, number];
+
+  /**
+   * Specify a noun and optionally, its pluaral form for what a value should be labeled as in a
+   * chart, i.e. "3 **points**", "20 **pacers**".
+   */
+  valueLabel?: string | [string, string];
 };
 
 enum IntervalWindow {
@@ -93,6 +104,8 @@ const ValueHistoryView: React.FC<Props> = ({
   icon,
   primaryColor,
   values,
+  valueLabel = ["", ""],
+  valueRange = [0, 10],
 }: Props) => {
   const [historyView, setHistoryView] = useState<"graph" | "table">("graph");
   const [intervalWindow, setIntervalWindow] = useState<IntervalWindow>(
@@ -143,8 +156,8 @@ const ValueHistoryView: React.FC<Props> = ({
           <p
             className={`text-2xl text-${primaryColor} font-semibold leading-none mb-1`}
           >
-            {averageValue.toFixed(1)}{" "}
-            <span className="text-dark text-base">/ 10</span>
+            {averageValue.toFixed(1)}
+            <span className="text-dark text-base">/ {valueRange[1]}</span>
           </p>
           <p className="text-sm text-unselected">
             Average {shortFieldLabel || fieldLabel}
@@ -255,7 +268,7 @@ const ValueHistoryView: React.FC<Props> = ({
             height={250}
             domain={{
               x: startDate && endDate ? [startDate, endDate] : undefined,
-              y: [0, 10],
+              y: valueRange,
             }}
             scale={{
               x: "time",
@@ -281,10 +294,7 @@ const ValueHistoryView: React.FC<Props> = ({
                   padding: "12",
                 },
               }}
-              tickValues={Array(11)
-                .fill(0)
-                .map((_, index: number) => index)}
-              tickFormat={(x) => (![0, 5, 10].includes(x) ? "" : x)}
+              tickCount={valueRange[1] - valueRange[0] + 1}
               dependentAxis
             />
             <VictoryAxis
@@ -332,8 +342,12 @@ const ValueHistoryView: React.FC<Props> = ({
                     year: "numeric",
                   }),
                   datum.value === 1
-                    ? `${datum.value} point`
-                    : `${datum.value} points`,
+                    ? `${datum.value} ${valueLabel}`
+                    : `${datum.value} ${
+                        Array.isArray(valueLabel)
+                          ? valueLabel[1]
+                          : `${valueLabel}s`
+                      }`,
                 ],
               }))}
               labelComponent={
@@ -367,7 +381,7 @@ const ValueHistoryView: React.FC<Props> = ({
                     top: -3,
                     bottom: -3,
                     left: 5,
-                    right: -5,
+                    right: -10,
                   }}
                   pointerLength={5}
                   pointerWidth={6}
@@ -377,7 +391,7 @@ const ValueHistoryView: React.FC<Props> = ({
               }
             >
               <VictoryArea
-                animate
+                animate={{ duration: 500 }}
                 style={{
                   data: {
                     fill: `url(#${primaryColor}ChartFill)`,
@@ -386,7 +400,7 @@ const ValueHistoryView: React.FC<Props> = ({
                 }}
               />
               <VictoryLine
-                animate
+                animate={{ duration: 500 }}
                 style={{
                   data: {
                     stroke: colors.palette[primaryColor],
@@ -430,6 +444,8 @@ const ValueHistoryView: React.FC<Props> = ({
 
 ValueHistoryView.defaultProps = {
   shortFieldLabel: undefined,
+  valueRange: [0, 10],
+  valueLabel: ["", ""],
 };
 
 export default ValueHistoryView;

--- a/components/Player/ValueHistoryView.tsx
+++ b/components/Player/ValueHistoryView.tsx
@@ -81,6 +81,17 @@ const ValueHistoryView: React.FC<Props> = ({
           </p>
         </div>
       </div>
+      <div className="mt-5 flex justify-between items-center text-sm">
+        <div className="font-semibold">
+          <label htmlFor="viewing-window">{fieldLabel} History for</label>
+          <select className="ml-3 select" id="viewing-window">
+            <option>This Year</option>
+            <option>This Month</option>
+            <option>Last 30 Days</option>
+            <option>Last 6 Months</option>
+          </select>
+        </div>
+      </div>
     </div>
   );
 };

--- a/components/Player/ValueHistoryView.tsx
+++ b/components/Player/ValueHistoryView.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { ProfileField } from "@prisma/client";
+import Icon, { IconType } from "components/Icon";
+import {
+  IProfileField,
+  ProfileFieldKey,
+  ProfileFieldValue,
+  ProfileFieldValues,
+} from "interfaces";
+import { deserializeProfileFieldValue } from "utils/buildUserProfile";
+import colors from "../../constants/colors";
+
+type NumericProfileFields = Exclude<
+  {
+    [K in ProfileFieldKey]: ProfileFieldValues[K] extends
+      | ProfileFieldValue.Integer
+      | ProfileFieldValue.Float
+      ? K
+      : never;
+  }[ProfileFieldKey],
+  never
+>;
+
+type Props = {
+  /**
+   * This label will be used as the header for the history view.
+   */
+  fieldLabel: string;
+
+  /**
+   * This label will be used as a short descriptor for the value type, i.e. Average "GPA" instead
+   * of Average Grade Point Average.
+   */
+  shortFieldLabel?: string;
+
+  icon: IconType;
+
+  primaryColor: keyof typeof colors.palette;
+
+  values: IProfileField<NumericProfileFields>[];
+};
+
+const ValueHistoryView: React.FC<Props> = ({
+  fieldLabel,
+  shortFieldLabel,
+  icon,
+  primaryColor,
+  values,
+}: Props) => {
+  const averageValue =
+    values.reduce(
+      (total: number, field: ProfileField) =>
+        total +
+        (deserializeProfileFieldValue<ProfileField, NumericProfileFields>(
+          field
+        ) ?? 0),
+      0
+    ) / values.filter((field: ProfileField) => field.value !== null).length;
+
+  return (
+    <div>
+      <h2 className="text-dark text-lg font-semibold mb-5">{fieldLabel}</h2>
+      <div className="flex items-center">
+        <div
+          className={`flex w-16 h-16 justify-center items-center bg-${primaryColor}-muted rounded-lg mr-6`}
+        >
+          <Icon
+            className={`text-${primaryColor} fill-current w-6 h-6`}
+            type={icon}
+          />
+        </div>
+        <div>
+          <p
+            className={`text-2xl text-${primaryColor} font-semibold leading-none mb-1`}
+          >
+            {averageValue.toFixed(1)}{" "}
+            <span className="text-dark text-base">/ 10</span>
+          </p>
+          <p className="text-sm text-unselected">
+            Average {shortFieldLabel || fieldLabel}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+ValueHistoryView.defaultProps = {
+  shortFieldLabel: undefined,
+};
+
+export default ValueHistoryView;

--- a/components/PlayersDashboard.tsx
+++ b/components/PlayersDashboard.tsx
@@ -23,7 +23,7 @@ const PlayerDashboardItem: React.FunctionComponent<Player> = ({
   const link = `/${session.sessionType}/players/${id}`;
   return (
     <Link href={link}>
-      <div role="button" className=" hover:bg-hoverState">
+      <div role="button" className=" hover:bg-hover">
         <hr className="border-unselected border-opacity-50" />
         <div className="grid grid-cols-3 gap-12 justify-items-start m-5">
           <div className="flex flex-row">

--- a/constants/colors.js
+++ b/constants/colors.js
@@ -1,0 +1,27 @@
+module.exports = {
+  dark: "#2C2C2C",
+  unselected: "#798393",
+  button: "#F5F7FA",
+  placeholder: "#E0E4E9",
+  border: "#A9AFB8",
+  hover: "#F7F9FB",
+
+  // All colors in palette are required to have a matching -muted counterpart in mutedPalette.
+  palette: {
+    blue: "#004284",
+    pink: "#C72E55",
+    gold: "#C0952A",
+    purple: "#3442BF",
+    danger: "#5C0018",
+    success: "#206000",
+  },
+
+  mutedPalette: {
+    "blue-muted": "#E9F4FF",
+    "pink-muted": "#FAE4E9",
+    "gold-muted": "#FBEECE",
+    "purple-muted": "#E3E6FF",
+    "danger-muted": "#FAE4E9",
+    "success-muted": "#DDF4D3",
+  },
+};

--- a/interfaces/user.ts
+++ b/interfaces/user.ts
@@ -99,12 +99,19 @@ export type ProfileFieldValueDeserializedTypes = {
   [ProfileFieldValue.TimeElapsed]: string;
 };
 
+export type IProfileField<K extends ProfileFieldKey> = Omit<
+  ProfileField,
+  "key"
+> & {
+  key: K;
+};
+
 export type PlayerProfile = {
   [K in ProfileFieldKey]: {
     key: K;
     current: ProfileFieldValueDeserializedTypes[ProfileFieldValues[K]] | null;
     lastUpdated: Date | null;
-    history: ProfileField[];
+    history: IProfileField<K>[];
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -49,9 +49,8 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-hook-form": "^6.9.6",
-    "semantic-ui-css": "^2.4.1",
-    "semantic-ui-react": "^2.0.1",
-    "tailwindcss": "^1.9.4"
+    "tailwindcss": "^1.9.4",
+    "victory": "^35.3.5"
   },
   "devDependencies": {
     "@prisma/cli": "2.11.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@prisma/client": "2.11.0",
     "@sendgrid/mail": "^7.4.0",
     "autoprefixer": "9.8.6",
+    "dayjs": "^1.9.6",
     "db-migrate": "^0.11.11",
     "db-migrate-base": "^2.3.0",
     "downshift": "^6.0.6",

--- a/pages/admin/players/index.tsx
+++ b/pages/admin/players/index.tsx
@@ -14,7 +14,7 @@ const AdminView: React.FunctionComponent = () => {
           <p className="pt-4 text-2xl font-display font-medium">All Players</p>
           <Link href="/admin/players/playerForm">
             <Button
-              className="font-display text-sm px-6 bg-lightBlue text-darkBlue rounded-lg h-10"
+              className="font-display text-sm px-6 bg-blue-muted text-blue rounded-lg h-10"
               iconType="plus"
             >
               Create new profile

--- a/pages/admin/players/playerForm/academics.tsx
+++ b/pages/admin/players/playerForm/academics.tsx
@@ -81,13 +81,13 @@ const UserSignUpPageOne: React.FC = () => {
                 <div className="flex mb-32 justify-between align-middle">
                   <div className="mb-2 flex">
                     <Button
-                      className="bg-darkBlue text-base px-5 py-2 text-white tracking-wide rounded-md"
+                      className="bg-blue text-base px-5 py-2 text-white tracking-wide rounded-md"
                       type="submit"
                     >
                       Save + Continue
                     </Button>
                     <Button
-                      className="border-2 border-darkBlue text-darkBlue bg-white text-base px-12 py-2 ml-10 rounded-md tracking-wide"
+                      className="border-2 border-blue text-blue bg-white text-base px-12 py-2 ml-10 rounded-md tracking-wide"
                       type="submit"
                     >
                       Cancel

--- a/pages/admin/players/playerForm/attendence.tsx
+++ b/pages/admin/players/playerForm/attendence.tsx
@@ -83,13 +83,13 @@ const UserSignUpPageOne: React.FC = () => {
                 <div className="flex mb-32 justify-between align-middle">
                   <div className="mb-2 flex">
                     <Button
-                      className="bg-darkBlue text-base px-5 py-2 text-white tracking-wide rounded-md"
+                      className="bg-blue text-base px-5 py-2 text-white tracking-wide rounded-md"
                       type="submit"
                     >
                       Save + Continue
                     </Button>
                     <Button
-                      className="border-2 border-darkBlue text-darkBlue bg-white text-base px-12 py-2 ml-10 rounded-md tracking-wide"
+                      className="border-2 border-blue text-blue bg-white text-base px-12 py-2 ml-10 rounded-md tracking-wide"
                       type="submit"
                     >
                       Cancel

--- a/pages/admin/players/playerForm/engagement.tsx
+++ b/pages/admin/players/playerForm/engagement.tsx
@@ -83,13 +83,13 @@ const UserSignUpPageOne: React.FC = () => {
                 <div className="flex mb-32 justify-between align-middle">
                   <div className="mb-2 flex">
                     <Button
-                      className="bg-darkBlue text-base px-5 py-2 text-white tracking-wide rounded-md"
+                      className="bg-blue text-base px-5 py-2 text-white tracking-wide rounded-md"
                       type="submit"
                     >
                       Save + Continue
                     </Button>
                     <Button
-                      className="border-2 border-darkBlue text-darkBlue bg-white text-base px-12 py-2 ml-10 rounded-md tracking-wide"
+                      className="border-2 border-blue text-blue bg-white text-base px-12 py-2 ml-10 rounded-md tracking-wide"
                       type="submit"
                     >
                       Cancel

--- a/pages/admin/players/playerForm/highlights.tsx
+++ b/pages/admin/players/playerForm/highlights.tsx
@@ -78,13 +78,13 @@ const UserSignUpPageOne: React.FC = () => {
                 <div className="flex mb-32 justify-between align-middle">
                   <div className="mb-2 flex">
                     <Button
-                      className="bg-darkBlue text-base px-12 py-2 text-white tracking-wide rounded-md"
+                      className="bg-blue text-base px-12 py-2 text-white tracking-wide rounded-md"
                       type="submit"
                     >
                       Submit
                     </Button>
                     <Button
-                      className="border-2 border-darkBlue text-darkBlue bg-white text-base px-12 py-2 ml-10 rounded-md tracking-wide"
+                      className="border-2 border-blue text-blue bg-white text-base px-12 py-2 ml-10 rounded-md tracking-wide"
                       type="submit"
                     >
                       Cancel

--- a/pages/admin/players/playerForm/index.tsx
+++ b/pages/admin/players/playerForm/index.tsx
@@ -144,13 +144,13 @@ const UserSignUpPageOne: React.FC = () => {
                 <div className="flex mb-32 justify-between align-middle">
                   <div className="mb-2 flex">
                     <Button
-                      className="bg-darkBlue text-sm px-5 py-2 text-white tracking-wide rounded-md"
+                      className="bg-blue text-sm px-5 py-2 text-white tracking-wide rounded-md"
                       type="submit"
                     >
                       Save + Continue
                     </Button>
                     <Button
-                      className="border-2 border-darkBlue text-darkBlue bg-white text-sm px-12 py-2 ml-10 rounded-md tracking-wide"
+                      className="border-2 border-blue text-blue bg-white text-sm px-12 py-2 ml-10 rounded-md tracking-wide"
                       type="submit"
                     >
                       Cancel

--- a/pages/admin/players/playerForm/overview.tsx
+++ b/pages/admin/players/playerForm/overview.tsx
@@ -161,13 +161,13 @@ const UserSignUpPageOne: React.FC = () => {
                 <div className="flex mb-32 justify-between align-middle">
                   <div className="mb-2 flex">
                     <Button
-                      className="bg-darkBlue text-base px-5 py-2 text-white tracking-wide rounded-md"
+                      className="bg-blue text-base px-5 py-2 text-white tracking-wide rounded-md"
                       type="submit"
                     >
                       Save + Continue
                     </Button>
                     <Button
-                      className="border-2 border-darkBlue text-darkBlue bg-white text-base px-12 py-2 ml-10 rounded-md tracking-wide"
+                      className="border-2 border-blue text-blue bg-white text-base px-12 py-2 ml-10 rounded-md tracking-wide"
                       type="submit"
                     >
                       Cancel

--- a/pages/admin/players/playerForm/physicalWellness.tsx
+++ b/pages/admin/players/playerForm/physicalWellness.tsx
@@ -169,13 +169,13 @@ const UserSignUpPageOne: React.FC = () => {
                 <div className="flex mb-32 justify-between align-middle">
                   <div className="mb-2 flex">
                     <Button
-                      className="bg-darkBlue text-base px-5 py-2 text-white tracking-wide rounded-md"
+                      className="bg-blue text-base px-5 py-2 text-white tracking-wide rounded-md"
                       type="submit"
                     >
                       Save + Continue
                     </Button>
                     <Button
-                      className="border-2 border-darkBlue text-darkBlue bg-white text-base px-12 py-2 ml-10 rounded-md tracking-wide"
+                      className="border-2 border-blue text-blue bg-white text-base px-12 py-2 ml-10 rounded-md tracking-wide"
                       type="submit"
                     >
                       Cancel

--- a/public/chevron.svg
+++ b/public/chevron.svg
@@ -1,0 +1,9 @@
+<svg width="9" height="6" viewBox="0 0 9 6" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path
+    d="M1 1L4.53554 4.53554L8.07107 1"
+    stroke="#798393"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -49,6 +49,14 @@ a {
     @apply w-full max-w-lg;
   }
 
+  .select {
+    @apply text-unselected border-unselected border rounded pl-4 pr-10 py-2 font-semibold appearance-none;
+    background-image: url(/chevron.svg);
+    background-position: calc(100% - 1rem) center;
+    background-repeat: no-repeat;
+    background-size: 10px;
+  }
+
   .tr-border {
     border-bottom-width: 0.5px;
     @apply border-border border-opacity-50;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,6 @@
+/* eslint-disable */
+const colors = require("./constants/colors");
+
 module.exports = {
   future: {
     // removeDeprecatedGapUtilities: true,
@@ -7,27 +10,13 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        dark: "#2C2C2C",
-        unselected: "#798393",
-        button: "#F5F7FA",
-        placeholder: "#E0E4E9",
-        hover: "#F7F9FB",
-        lightBlue: "#E9F4FF",
-        darkBlue: "#004284",
-        hoverState: "#F7F9FB",
-        border: "#A9AFB8",
-        blue: "#004284",
-        "blue-muted": "#E9F4FF",
-        pink: "#C72E55",
-        "pink-muted": "#FAE4E9",
-        gold: "#C0952A",
-        "gold-muted": "#FBEECE",
-        purple: "#3442BF",
-        "purple-muted": "#E3E6FF",
-        danger: "#5C0018",
-        "danger-muted": "#FAE4E9",
-        success: "#206000",
-        "success-muted": "#DDF4D3",
+        ...Object.fromEntries(
+          Object.entries(colors).filter(
+            ([name]) => name !== "palette" || name !== "mutedPalette"
+          )
+        ),
+        ...colors.palette,
+        ...colors.mutedPalette,
       },
     },
     fontFamily: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,5 @@
     "target": "esnext"
   },
   "exclude": ["node_modules"],
-  "include": ["**/*.ts", "**/*.tsx"]
+  "include": ["**/*.ts", "**/*.tsx", "constants/colors.js"]
 }

--- a/utils/buildUserProfile.ts
+++ b/utils/buildUserProfile.ts
@@ -1,5 +1,6 @@
 import { Absence, ProfileField } from "@prisma/client";
 import {
+  IProfileField,
   PlayerProfile,
   ProfileFieldKey,
   ProfileFieldValue,
@@ -8,10 +9,13 @@ import {
   SanitizedUser,
 } from "interfaces";
 
-export const deserializeProfileFieldValue = <T extends ProfileField>(
+export const deserializeProfileFieldValue = <
+  T extends ProfileField,
+  K extends ProfileFieldKey = T["key"]
+>(
   field: T
-): ProfileFieldValueDeserializedTypes[ProfileFieldValues[T["key"]]] | null => {
-  type Deserialized = ProfileFieldValueDeserializedTypes[ProfileFieldValues[T["key"]]];
+): ProfileFieldValueDeserializedTypes[ProfileFieldValues[K]] | null => {
+  type Deserialized = ProfileFieldValueDeserializedTypes[ProfileFieldValues[K]];
   switch (ProfileFieldValues[field.key]) {
     case ProfileFieldValue.Float:
       return Number(field.value) as Deserialized;
@@ -59,7 +63,9 @@ export default function buildUserProfile<
         field.createdAt
       );
     }
-    transformedUser.profile[field.key].history.push(field);
+    (transformedUser.profile[field.key].history as IProfileField<
+      typeof field.key
+    >[]).push(field);
   });
   return transformedUser;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -980,7 +980,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.10.5", "@babel/runtime@^7.11.2", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.8.4":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
   integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
@@ -1044,21 +1044,6 @@
     lodash "^4.17.19"
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
-
-"@fluentui/react-component-event-listener@~0.51.1":
-  version "0.51.2"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-component-event-listener/-/react-component-event-listener-0.51.2.tgz#bb403c96acfa9fb4ea338f3f2bf66e672085a4c7"
-  integrity sha512-myfDuwU/MRGH5hqldLmwfMAn7FoXCCspdknWg+A0Tyf+mjUsgWlqRewLapon8mJqprZzrH1obPxONV/lVI3Quw==
-  dependencies:
-    "@babel/runtime" "^7.10.4"
-
-"@fluentui/react-component-ref@~0.51.1":
-  version "0.51.2"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-component-ref/-/react-component-ref-0.51.2.tgz#17d27ce4da914e162a9ac4f3f4a7810d1ade658a"
-  integrity sha512-LE3NXMHJ5K2ZgTf+p/l4cDRYwmfXTw1XhjZLBI0sZaggbaUxMgrfvr0DHvkcZrbr3aLMaILYoQrTjP9Y1w0veA==
-  dependencies:
-    "@babel/runtime" "^7.10.4"
-    react-is "^16.6.3"
 
 "@fullhuman/postcss-purgecss@^2.1.2":
   version "2.3.0"
@@ -1154,11 +1139,6 @@
   resolved "https://registry.yarnpkg.com/@panva/asn1.js/-/asn1.js-1.0.0.tgz#dd55ae7b8129e02049f009408b97c61ccf9032f6"
   integrity sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==
 
-"@popperjs/core@^2.5.2":
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.5.4.tgz#de25b5da9f727985a3757fd59b5d028aba75841a"
-  integrity sha512-ZpKr+WTb8zsajqgDkvCEWgp6d5eJT6Q63Ng2neTbzBO76Lbe91vX/iVIW9dikq+Fs3yEo+ls4cxeXABD2LtcbQ==
-
 "@prisma/bar@0.0.1":
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@prisma/bar/-/bar-0.0.1.tgz#088c4fbbb79c588391437ade9fd3a85527e753b3"
@@ -1188,14 +1168,6 @@
   version "2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918"
   resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918.tgz#5f02f311ce48297ef3fa9861dcab5ec3e52f1371"
   integrity sha512-0WaUybWM7J5zQuG/zYLbV+ZKx9/nzS7Ruu7Y0K2lXJKy3Z9koeVttq+Xt7tVmUX9TLgI1Rwhb9R2e1JMNDWbsw==
-
-"@semantic-ui-react/event-stack@^3.1.0":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@semantic-ui-react/event-stack/-/event-stack-3.1.1.tgz#3263d17511db81a743167fe45281a24b3eb6b3c8"
-  integrity sha512-SA7VOu/tY3OkooR++mm9voeQrJpYXjJaMHO1aFCcSouS2xhqMR9Gnz0LEGLOR0h9ueWPBKaQzKIrx3FTTJZmUQ==
-  dependencies:
-    exenv "^1.2.2"
-    prop-types "^15.6.2"
 
 "@sendgrid/client@^7.4.0":
   version "7.4.0"
@@ -2455,11 +2427,6 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
-clsx@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
-  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
-
 collection-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
@@ -2824,6 +2791,90 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
+d3-array@^1.2.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
+  integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
+
+d3-array@^2.4.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.8.0.tgz#f76e10ad47f1f4f75f33db5fc322eb9ffde5ef23"
+  integrity sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw==
+
+d3-collection@1:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
+  integrity sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==
+
+d3-color@1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"
+  integrity sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==
+
+d3-ease@^1.0.0:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.7.tgz#9a834890ef8b8ae8c558b2fe55bd57f5993b85e2"
+  integrity sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ==
+
+d3-format@1:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.5.tgz#374f2ba1320e3717eb74a9356c67daee17a7edb4"
+  integrity sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==
+
+d3-interpolate@1, d3-interpolate@^1.1.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.4.0.tgz#526e79e2d80daa383f9e0c1c1c7dcc0f0583e987"
+  integrity sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==
+  dependencies:
+    d3-color "1"
+
+d3-path@1:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.9.tgz#48c050bb1fe8c262493a8caf5524e3e9591701cf"
+  integrity sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==
+
+d3-scale@^1.0.0:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-1.0.7.tgz#fa90324b3ea8a776422bd0472afab0b252a0945d"
+  integrity sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==
+  dependencies:
+    d3-array "^1.2.0"
+    d3-collection "1"
+    d3-color "1"
+    d3-format "1"
+    d3-interpolate "1"
+    d3-time "1"
+    d3-time-format "2"
+
+d3-shape@^1.0.0, d3-shape@^1.2.0:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.7.tgz#df63801be07bc986bc54f63789b4fe502992b5d7"
+  integrity sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==
+  dependencies:
+    d3-path "1"
+
+d3-time-format@2:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.3.0.tgz#107bdc028667788a8924ba040faf1fbccd5a7850"
+  integrity sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==
+  dependencies:
+    d3-time "1"
+
+d3-time@1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.1.0.tgz#b1e19d307dae9c900b7e5b25ffc5dcc249a8a0f1"
+  integrity sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==
+
+d3-timer@^1.0.0:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.10.tgz#dfe76b8a91748831b13b6d9c793ffbd508dd9de5"
+  integrity sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==
+
+d3-voronoi@^1.1.2:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/d3-voronoi/-/d3-voronoi-1.1.4.tgz#dd3c78d7653d2bb359284ae478645d95944c8297"
+  integrity sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg==
+
 d@1, d@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
@@ -2987,6 +3038,18 @@ defined@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
   integrity sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=
+
+delaunator@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-4.0.1.tgz#3d779687f57919a7a418f8ab947d3bddb6846957"
+  integrity sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==
+
+delaunay-find@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/delaunay-find/-/delaunay-find-0.0.5.tgz#5fb37e6509da934881b4b16c08898ac89862c097"
+  integrity sha512-7yAJ/wmKWj3SgqjtkGqT/RCwI0HWAo5YnHMoF5nYXD8cdci+YSo23iPmgrZUNOpDxRWN91PqxUvMMr2lKpjr+w==
+  dependencies:
+    delaunator "^4.0.0"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -3581,11 +3644,6 @@ execa@^4.0.3:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
-
-exenv@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
-  integrity sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=
 
 expand-brackets@^2.1.4:
   version "2.1.4"
@@ -4511,11 +4569,6 @@ jose@^1.27.2, jose@^1.28.0:
   dependencies:
     "@panva/asn1.js" "^1.0.0"
 
-jquery@x.*:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
-  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
-
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -4558,6 +4611,11 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
+
+json-stringify-safe@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+  integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
 json5@^1.0.1:
   version "1.0.1"
@@ -4638,11 +4696,6 @@ jwt-decode@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-2.2.0.tgz#7d86bd56679f58ce6a84704a657dd392bba81a79"
   integrity sha1-fYa9VmefWM5qhHBKZX3TkruoGnk=
-
-keyboard-key@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/keyboard-key/-/keyboard-key-1.1.0.tgz#6f2e8e37fa11475bb1f1d65d5174f1b35653f5b7"
-  integrity sha512-qkBzPTi3rlAKvX7k0/ub44sqOfXeLc/jcnGGmj5c7BJpU8eDrEVPyhCvNYAaoubbsLm9uGWwQJO1ytQK1a9/dQ==
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -4809,11 +4862,6 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
-
-lodash-es@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
-  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
 
 lodash.debounce@^4.0.8:
   version "4.0.8"
@@ -6132,7 +6180,7 @@ prompt@^1.0.0:
     utile "0.3.x"
     winston "2.1.x"
 
-prop-types@15.7.2, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.7.2, prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -6253,28 +6301,20 @@ react-dom@16.13.1:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-fast-compare@^3.0.1:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
-  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+react-fast-compare@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
+  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
 react-hook-form@^6.9.6:
   version "6.9.6"
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.9.6.tgz#bbcdfa34a660edcdd160cba2d501583b0e3d60a9"
   integrity sha512-TyLqWHgFS1WLELDuUBvMWLHEzmR7aS7xOY+eOxMtS1w4jFhqF1xmHnMhJsbiFPSgC+OeTJ1Pc0U4K0y6cA7ERA==
 
-react-is@16.13.1, react-is@^16.13.1, react-is@^16.6.3, react-is@^16.8.1, react-is@^16.8.6:
+react-is@16.13.1, react-is@^16.13.1, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
-
-react-popper@^2.2.3:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.4.tgz#d2ad3d2474ac9f1abf93df3099d408e5aa6a2e22"
-  integrity sha512-NacOu4zWupdQjVXq02XpTD3yFPSfg5a7fex0wa3uGKVkFK7UN6LvVxgcb+xYr56UCuWiNPMH20tntdVdJRwYew==
-  dependencies:
-    react-fast-compare "^3.0.1"
-    warning "^4.0.2"
 
 react-refresh@0.8.3:
   version "0.8.3"
@@ -6666,32 +6706,6 @@ schema-utils@^2.6.1, schema-utils@^2.6.6:
     ajv "^6.12.4"
     ajv-keywords "^3.5.2"
 
-semantic-ui-css@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/semantic-ui-css/-/semantic-ui-css-2.4.1.tgz#f5aea39fafb787cbd905ec724272a3f9cba9004a"
-  integrity sha512-Pkp0p9oWOxlH0kODx7qFpIRYpK1T4WJOO4lNnpNPOoWKCrYsfHqYSKgk5fHfQtnWnsAKy7nLJMW02bgDWWFZFg==
-  dependencies:
-    jquery x.*
-
-semantic-ui-react@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/semantic-ui-react/-/semantic-ui-react-2.0.1.tgz#a69aa65001c437ae0b3ed747d1f43ee5b4e88407"
-  integrity sha512-l1g9ZTRHqe+nSgcTuaTTxnnIdPAgyzoAZY35ciL0pjopeC7mWxNVhBqm98tmR0kgoL7NvWjY+Dy/AUc3l6FVKw==
-  dependencies:
-    "@babel/runtime" "^7.10.5"
-    "@fluentui/react-component-event-listener" "~0.51.1"
-    "@fluentui/react-component-ref" "~0.51.1"
-    "@popperjs/core" "^2.5.2"
-    "@semantic-ui-react/event-stack" "^3.1.0"
-    clsx "^1.1.1"
-    keyboard-key "^1.1.0"
-    lodash "^4.17.19"
-    lodash-es "^4.17.15"
-    prop-types "^15.7.2"
-    react-is "^16.8.6"
-    react-popper "^2.2.3"
-    shallowequal "^1.1.0"
-
 semver-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
@@ -6768,11 +6782,6 @@ shallow-clone@^3.0.0:
   integrity sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==
   dependencies:
     kind-of "^6.0.2"
-
-shallowequal@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
-  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -7665,6 +7674,306 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
+victory-area@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-area/-/victory-area-35.3.5.tgz#8cc8e560cb52f478cfe3aa7743822a08722845b6"
+  integrity sha512-W5JuMLCVHjysom1vnwFHXmuAXfAjmzZ4RWDVv0GZTUyZKDjZ0yD0XRKvrLcuN7cX702/5I3T1tf8N7TBICD7Lw==
+  dependencies:
+    d3-shape "^1.2.0"
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    victory-core "^35.3.5"
+
+victory-axis@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-axis/-/victory-axis-35.3.5.tgz#5305b1215f844b17f2278500619d4c9b47ab2b8f"
+  integrity sha512-E3E/MjwoFIWLGbn3TU13eUwa+t0FrG4M44uwKUmpmt6U7YCHmMcxb/WkOTyvAuytQl0jcPRI+mI3dNcqxCYhbQ==
+  dependencies:
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    victory-core "^35.3.5"
+
+victory-bar@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-bar/-/victory-bar-35.3.5.tgz#60ce981ef6acf2fd86519cfa31856ab5e8a80874"
+  integrity sha512-BDqdWOSubHb+aMvtN6zm5HaNNv4N66xSrHNIr2GC+FFnLp4wWuKtVdx5O4bmiVYWkdXMj1zrMu6KnWfe3/qb1w==
+  dependencies:
+    d3-shape "^1.2.0"
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    victory-core "^35.3.5"
+
+victory-box-plot@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-box-plot/-/victory-box-plot-35.3.5.tgz#cc7d98d7ddc8c3df2faeb3798f3b87fca4c7d022"
+  integrity sha512-rsX7sQt1qhNVc/1+hSBsU0Rb5WvbBbE/2uQ+7NWKVF744O4/VJLYEYV0DqmrjJtlUo6KP40oL+Ns04c1kv+rzA==
+  dependencies:
+    d3-array "^1.2.0"
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    victory-core "^35.3.5"
+
+victory-brush-container@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-brush-container/-/victory-brush-container-35.3.5.tgz#7dfa23334f0b5b29ad5eeee20c06f3b3d856a893"
+  integrity sha512-UrzPDKt/PPxhrhbt9xyKxlny52ACAvJHBXdGOohLgtaFjt6xHyFTO6mvmjXtZlt8SxHf3KTc2lezi37b4DsmgA==
+  dependencies:
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+    victory-core "^35.3.5"
+
+victory-brush-line@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-brush-line/-/victory-brush-line-35.3.5.tgz#82f26f7010398df981fd8705696a9cfd26b8be13"
+  integrity sha512-YEhTLEY5ImnSBj5fMDGLGpbVPlFkd04PkACXJP4dNsgv4xwJPBbcgRY2DAvkdbpj7Zu6TenRG9AzEU9afM7chw==
+  dependencies:
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+    victory-core "^35.3.5"
+
+victory-candlestick@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-candlestick/-/victory-candlestick-35.3.5.tgz#0398c94ff369d9d624b3baa9ac5a28ac204ab54f"
+  integrity sha512-V+dK9tqjYMNK7MgJ+zZy1eif9l77xBgMIORVMbwauBPIkiL8Z5eulO+Y9/vq33/4JezDrJFH41WEW+Lg9PonzA==
+  dependencies:
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    victory-core "^35.3.5"
+
+victory-chart@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-chart/-/victory-chart-35.3.5.tgz#b99aea41a2fc487a58587057b3ee4e132e450246"
+  integrity sha512-ByKrqQzZbkw1mvqdSvRrfsSiAZpJ8AAWjeLa1BAfgKwXf/qdoKwU8flCG5cySWNhorUHyNrzFY9vYmzvA0nW8A==
+  dependencies:
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+    victory-axis "^35.3.5"
+    victory-core "^35.3.5"
+    victory-polar-axis "^35.3.5"
+    victory-shared-events "^35.3.5"
+
+victory-core@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-core/-/victory-core-35.3.5.tgz#0b89235a312ab9b430642c5593517b3cba649faa"
+  integrity sha512-HhxuXA26X5QZQ/TYsXNUfKtZDHMgTDoA97ln32fV2EDHk1+Sg4KIbMJAaOgsy+2b8y5uUE2Gc37gzABKGhc8dA==
+  dependencies:
+    d3-ease "^1.0.0"
+    d3-interpolate "^1.1.1"
+    d3-scale "^1.0.0"
+    d3-shape "^1.2.0"
+    d3-timer "^1.0.0"
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+
+victory-create-container@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-create-container/-/victory-create-container-35.3.5.tgz#d958da42979a2c641a4eaf82363d16fb8ed8fff6"
+  integrity sha512-bDk7F/3a8pXOYjq61MEgpX4f7koatZb2v35n2ZgxoUliXIS1YQ+4bC9gYU3QPVoFDH2xGpwF/MSIKOecxcwwbA==
+  dependencies:
+    lodash "^4.17.19"
+    victory-brush-container "^35.3.5"
+    victory-core "^35.3.5"
+    victory-cursor-container "^35.3.5"
+    victory-selection-container "^35.3.5"
+    victory-voronoi-container "^35.3.5"
+    victory-zoom-container "^35.3.5"
+
+victory-cursor-container@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-cursor-container/-/victory-cursor-container-35.3.5.tgz#821a15990fc33b3ca2c448ffa1d74ad6cf9b88fb"
+  integrity sha512-e1XdEFmh+/VOl6kxMzbqe94DsbOnmzDtFVVx58z1XCMONJIxCVtppG0D88FCyrj8fHFIVnUlHkSObYM9G1kRvg==
+  dependencies:
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    victory-core "^35.3.5"
+
+victory-errorbar@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-errorbar/-/victory-errorbar-35.3.5.tgz#92313a0c7948a754d25b8f772b33cddbfe71d112"
+  integrity sha512-JfuZSCI8lu8AQZ7eja+5eId9Vc4v7qG1Vy/aFp2j+glxINKCCf7Z/oJDKkIRp+ayzFb98T6Cz5LlXdLk9Kj4dw==
+  dependencies:
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    victory-core "^35.3.5"
+
+victory-group@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-group/-/victory-group-35.3.5.tgz#12bcbf6ebf65376a4990891534bc18de7c60fcec"
+  integrity sha512-pRTSb1bPOCQCpK5/eHsTuqiSfb8YRGUKVV1YpZAjDy7tVauF10gdbtItCE1W16rgEd9BrU9MgQZp0May76G2Mw==
+  dependencies:
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+    victory-core "^35.3.5"
+    victory-shared-events "^35.3.5"
+
+victory-histogram@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-histogram/-/victory-histogram-35.3.5.tgz#95ccffc8ee08cce5b88b24da9ab1240414f4300f"
+  integrity sha512-eztr8KjA5AAgPLCLWvqnyETOpMhZC+VuUbcISPHJ0n+0Icxy1eawHSPX8pbhPprYg0OoVnDApNsq4gJDcHSk3Q==
+  dependencies:
+    d3-array "^2.4.0"
+    d3-scale "^1.0.0"
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+    victory-bar "^35.3.5"
+    victory-core "^35.3.5"
+
+victory-legend@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-legend/-/victory-legend-35.3.5.tgz#91796f69f74a3fff66564f0754b6f19bf3d7ada8"
+  integrity sha512-wDSYd88q6INYeM94vGd+jqNYLnTF8Q6zuqfQzuksq+QCkJfFVFkOpD83PPzPVYohCwmlPLCPnVo2VEew3fglAQ==
+  dependencies:
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    victory-core "^35.3.5"
+
+victory-line@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-line/-/victory-line-35.3.5.tgz#4e6a955ebad3404a5c2326de979b868bd973e8b8"
+  integrity sha512-//5Lk/LwdBrnBa5Y3y9zkImFL45EySnS+uRUT8OrJOD41Tx5vVRpTAtJ1Ia+lhQ3QKfFvpk/x4tI1nJljE001Q==
+  dependencies:
+    d3-shape "^1.2.0"
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    victory-core "^35.3.5"
+
+victory-pie@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-pie/-/victory-pie-35.3.5.tgz#fe3de4251fa2c1748bc941209ce44087918cea78"
+  integrity sha512-HR8p8wK5J9Etikicll0cRGchKiB2v7w5iqyV4BzBx2FTvE/5VzAWBm0RjyRqS5ykM2TfDc3lrz1zXsPB2vhcpw==
+  dependencies:
+    d3-shape "^1.0.0"
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    victory-core "^35.3.5"
+
+victory-polar-axis@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-polar-axis/-/victory-polar-axis-35.3.5.tgz#f89ebbbe9b3d7f0d4153271fd2a92284987cf786"
+  integrity sha512-i0PdkxxgIFeW1jGHkczGPlHW4reWWXDEhaN/L4dByqv0GmOCRY+HoMxnNgQ9nNQideeHt3BuJWgd4SjPOS6a3A==
+  dependencies:
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    victory-core "^35.3.5"
+
+victory-scatter@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-scatter/-/victory-scatter-35.3.5.tgz#f4651c7ebb0eb626689308f58b53bf85f01336da"
+  integrity sha512-we21KDpK6vWZBZnY2LddA4nGmYF3rif5MC9F1hxxJpVX5nVLCqXXJsQgLB8zUKYbWRZVIzzpIp/sDYc1MvSC1g==
+  dependencies:
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    victory-core "^35.3.5"
+
+victory-selection-container@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-selection-container/-/victory-selection-container-35.3.5.tgz#9bca411d8b2c6b3bc2ec33aa2a7ebceb5faeb563"
+  integrity sha512-iFQZjtD69PYO8RWf4FXKsyS06WGin+0gSUTSW22zEOOTdrzW94yy+F3/EPIUpbwwtMNDm2moctuLgF8Tjd//zA==
+  dependencies:
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    victory-core "^35.3.5"
+
+victory-shared-events@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-shared-events/-/victory-shared-events-35.3.5.tgz#e3efe1c27c85c710957a005ba6b3270e5da758a5"
+  integrity sha512-KUEYZsHTEkO8GlENUoJm5DvcKfvJFrVB4ebtU8kArkTrh/bQFaIWmmyWgGxfFlOzxUcWrxJntXinHse3QKtq8Q==
+  dependencies:
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+    victory-core "^35.3.5"
+
+victory-stack@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-stack/-/victory-stack-35.3.5.tgz#aff896c3bae4c2bcfc337be8d6dbc7557ca495eb"
+  integrity sha512-nO8u7qVvhsreIRxI+8hrzqXqmXr/vgEObS168MuAmhDV7JUV2cnDK9MEHMPPAvM2Anq4o/AYLBifSjQbwkCulQ==
+  dependencies:
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+    victory-core "^35.3.5"
+    victory-shared-events "^35.3.5"
+
+victory-tooltip@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-tooltip/-/victory-tooltip-35.3.5.tgz#985ee8e84162d042304e90cdaf05bfbdfc5f7ca7"
+  integrity sha512-i0VfBYPsm1z3MSoe8a8EPrB4Ytg+6avjBCHbr5//9Sa9eqWzslx1cvVdl1+q6ibC2fCNQpW8W6pmk8FIYHfMAg==
+  dependencies:
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    victory-core "^35.3.5"
+
+victory-voronoi-container@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-voronoi-container/-/victory-voronoi-container-35.3.5.tgz#6932a71dc68d207eca30f5c540349d79c0d69678"
+  integrity sha512-+qkb0Bk4KpVtNjGDBWeXVBQajuJk5oxH2n9C1fMbLYNKlxjojXTYm5PkZlc5zH4aDSkhK/XFQWf+W67fnqHlTw==
+  dependencies:
+    delaunay-find "0.0.5"
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+    victory-core "^35.3.5"
+    victory-tooltip "^35.3.5"
+
+victory-voronoi@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-voronoi/-/victory-voronoi-35.3.5.tgz#ba7975b61b2414797e5385ca6d9c5b9c1581a7c6"
+  integrity sha512-H8W6So0hCM2l8vJEeaFaHnG0T9oh1FoNWMZXkr8kxo+/38GbvLQLtLovdccYyMNmp5BDxaZ3MZGT0QipbnCVYg==
+  dependencies:
+    d3-voronoi "^1.1.2"
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    victory-core "^35.3.5"
+
+victory-zoom-container@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-zoom-container/-/victory-zoom-container-35.3.5.tgz#474819052a2422d72f5066b5e906d8fb7b41e6a7"
+  integrity sha512-pVYNB0X0d6wzmM+T4HRobkC8JXfrd1fOJmNbipz4p4NN5Zef+s7bI/8TvoU4kpOmcgjJREO6qNy9bdg+fpndfg==
+  dependencies:
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    victory-core "^35.3.5"
+
+victory@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory/-/victory-35.3.5.tgz#4ddce964a9003182dac81e46b2b4a6c81b13964b"
+  integrity sha512-/sJCSTWVsR92kZeRHtYqgzKlAxYTAk5GgxcMLZKhv61gcan//m6FgMWRkLTeGPZAmVwa+e3iFq5gDxzqcrBw1w==
+  dependencies:
+    victory-area "^35.3.5"
+    victory-axis "^35.3.5"
+    victory-bar "^35.3.5"
+    victory-box-plot "^35.3.5"
+    victory-brush-container "^35.3.5"
+    victory-brush-line "^35.3.5"
+    victory-candlestick "^35.3.5"
+    victory-chart "^35.3.5"
+    victory-core "^35.3.5"
+    victory-create-container "^35.3.5"
+    victory-cursor-container "^35.3.5"
+    victory-errorbar "^35.3.5"
+    victory-group "^35.3.5"
+    victory-histogram "^35.3.5"
+    victory-legend "^35.3.5"
+    victory-line "^35.3.5"
+    victory-pie "^35.3.5"
+    victory-polar-axis "^35.3.5"
+    victory-scatter "^35.3.5"
+    victory-selection-container "^35.3.5"
+    victory-shared-events "^35.3.5"
+    victory-stack "^35.3.5"
+    victory-tooltip "^35.3.5"
+    victory-voronoi "^35.3.5"
+    victory-voronoi-container "^35.3.5"
+    victory-zoom-container "^35.3.5"
+
 vm-browserify@1.1.2, vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
@@ -7700,13 +8009,6 @@ vscode-uri@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-2.1.2.tgz#c8d40de93eb57af31f3c715dd650e2ca2c096f1c"
   integrity sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==
-
-warning@^4.0.2:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
-  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
-  dependencies:
-    loose-envify "^1.0.0"
 
 watchpack-chokidar2@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2895,6 +2895,11 @@ data-uri-to-buffer@3.0.0:
   dependencies:
     buffer-from "^1.1.1"
 
+dayjs@^1.9.6:
+  version "1.9.6"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.9.6.tgz#6f0c77d76ac1ff63720dd1197e5cb87b67943d70"
+  integrity sha512-HngNLtPEBWRo8EFVmHFmSXAjtCX8rGNqeXQI0Gh7wCTSqwaKgPIDqu9m07wABVopNwzvOeCb+2711vQhDlcIXw==
+
 db-migrate-base@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/db-migrate-base/-/db-migrate-base-2.3.0.tgz#e1539c733caa6de59bb06db6b230a8fd451c081f"


### PR DESCRIPTION
* Update seeding script to insert values across a range of dates from 2020
* Move colors to constants file (now imported from Tailwind) for use in the rest of the codebase (with types!)
* Adds ValueHistoryView component, which displays an average of values over time, with toggleable graph/table views
  * Adds `victory` as a new dependency for SVG charting

## TODO

- [x] Update label component to include month
- [x] Add time window functionality (need to get exact windows expected from Rach)
- (_Separate ticket_) Migrate engagement score values over to object structure that can include a description (and a date, to support retroactive scoring)

## How to Test/Use PR feature

- Run `yarn` to pull in new dependencies.
- For best results, re-run `yarn db:seed`.
- Navigate to a player profile's Engagement tab.

## PR Checklist

Does your branch (check if true):
- [x] work when you run `yarn build`?
- [x] successfully run `yarn:db-migrate up` without yielding any errors?
- [x] successfully run `yarn prisma introspect` without yielding any errors?
- [x] successfully run `yarn dev` and support all changes that your branch intends to perform?

## Screenshots

![image](https://user-images.githubusercontent.com/2977329/99157911-0d8ed300-2682-11eb-9f87-117ae82fbbcb.png)

![image](https://user-images.githubusercontent.com/2977329/99157915-18496800-2682-11eb-9078-6aab467a3a4b.png)

CC: @erinysong
