### PR TITLE
Completed player association flow

### DIFF
--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 type Props = React.PropsWithChildren<{
-  text: string;
+  text: string | null;
   onDelete: React.MouseEventHandler;
 }>;
 

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -9,7 +9,7 @@ const Card: React.FC<Props> = ({ children, text, onDelete }: Props) => {
   return (
     <div className="rounded-md border border-gray-500 my-3 w-1/3">
       <div className="flex justify-between p-2">
-        <div className="">{text}</div>
+        <div>{text}</div>
         <button
           type="button"
           className="text-gray-500 hover:font-bold hover:text-black"

--- a/components/Combobox.tsx
+++ b/components/Combobox.tsx
@@ -42,7 +42,7 @@ const Combobox: React.FC<Props> = ({
     highlightedIndex,
     getItemProps,
     selectedItem,
-    selectItem,
+    reset,
   } = useCombobox({
     isOpen: focused,
     items: inputPlayers,
@@ -69,9 +69,9 @@ const Combobox: React.FC<Props> = ({
       setSelectedPlayers(() => [...selectedPlayers, selectedItem]);
       setFocused(false);
       setQuery("");
-      selectItem(null);
+      reset();
     }
-  }, [selectItem, selectedItem, selectedPlayers, setSelectedPlayers]);
+  }, [reset, selectedItem, selectedPlayers, setSelectedPlayers]);
 
   const onDelete = (user: User): void => {
     setSelectedPlayers(

--- a/components/Combobox.tsx
+++ b/components/Combobox.tsx
@@ -3,28 +3,31 @@ import { useCombobox } from "downshift";
 import { User } from "@prisma/client";
 import debounce from "lodash.debounce";
 import Button from "./Button";
+import Card from "./Card";
 
 const getInputPlayers = async (
   inputValue: string | undefined,
-  selectedPlayers: string[]
-): Promise<string[]> => {
+  selectedPlayers: User[]
+): Promise<User[]> => {
   try {
     const apiLink = `http://localhost:3000/api/admin/users/search/${inputValue}`;
     const response = await fetch(apiLink);
     const data = await response.json();
-    return data.users
-      .map((player: User) => player.name)
-      .filter(function removeSelected(item: string) {
-        return !selectedPlayers.includes(item);
-      });
+    return (
+      data.users
+        // .map((player: User) => player.name)
+        .filter(function removeSelected(player: User) {
+          return !selectedPlayers.includes(player);
+        })
+    );
   } catch (err) {
     throw new Error(err.message);
   }
 };
 
 const Combobox: React.FC = () => {
-  const [inputPlayers, setInputPlayers] = useState<string[]>([]);
-  const [selectedPlayers, setSelectedPlayers] = useState<string[]>([]);
+  const [inputPlayers, setInputPlayers] = useState<User[]>([]);
+  const [selectedPlayers, setSelectedPlayers] = useState<User[]>([]);
   const [query, setQuery] = useState("");
   const [focused, setFocused] = useState(false);
   const input = useRef<HTMLInputElement | null>(null);
@@ -65,16 +68,17 @@ const Combobox: React.FC = () => {
       setSelectedPlayers(() => [...selectedPlayers, selectedItem]);
       setFocused(false);
       setQuery("");
-      selectItem("");
+      selectItem(null);
     }
   }, [selectItem, selectedItem, selectedPlayers]);
 
   return (
     <div className="container  w-4/5 mt-3">
       <div className="relative">
-        <pre className="text-xs">
+        {/* <pre className="text-xs">
           selected: {JSON.stringify(selectedPlayers)}
-        </pre>
+        </pre> */}
+        <Card text="hello" onDelete={() => console.log("deleting")} />
 
         <div>
           <div {...getComboboxProps()}>
@@ -95,24 +99,24 @@ const Combobox: React.FC = () => {
                 onChange: (event: React.ChangeEvent<HTMLInputElement>) =>
                   setQuery(event.target.value),
               })}
-              className={`w-1/4 text-base form-input leading-10 ${
+              className={`w-1/3 text-base form-input leading-10 ${
                 !focused ? "hidden" : ""
               }`}
             />
           </div>
           <ul
             {...getMenuProps()}
-            className={`absolute w-1/4 bg-white border border-b-0 rounded-sm mt-2 ${
+            className={`absolute w-1/3 bg-white border border-b-0 rounded-sm mt-2 ${
               !isOpen ? "hidden" : ""
             }`}
           >
             {isOpen &&
-              inputPlayers.map((item: string, index: number) => (
+              inputPlayers.map((item: User, index: number) => (
                 <li
                   className={`${
                     highlightedIndex === index ? "bg-lightBlue" : ""
                   } px-3 py-2 border-b`}
-                  key={`${item}`}
+                  key={`${item.name}`}
                   {...getItemProps({
                     item,
                     index,
@@ -120,7 +124,7 @@ const Combobox: React.FC = () => {
                       event.preventDefault(),
                   })}
                 >
-                  {item}
+                  {item.name}
                 </li>
               ))}
           </ul>

--- a/components/Combobox.tsx
+++ b/components/Combobox.tsx
@@ -13,21 +13,24 @@ const getInputPlayers = async (
     const apiLink = `http://localhost:3000/api/admin/users/search/${inputValue}`;
     const response = await fetch(apiLink);
     const data = await response.json();
-    return (
-      data.users
-        // .map((player: User) => player.name)
-        .filter(function removeSelected(player: User) {
-          return !selectedPlayers.includes(player);
-        })
+    return data.users.filter(
+      (player: User) => !selectedPlayers.some(({ id }) => id === player.id)
     );
   } catch (err) {
     throw new Error(err.message);
   }
 };
 
-const Combobox: React.FC = () => {
+type Props = React.PropsWithChildren<{
+  selectedPlayers: User[];
+  setSelectedPlayers: React.Dispatch<React.SetStateAction<User[]>>;
+}>;
+
+const Combobox: React.FC<Props> = ({
+  selectedPlayers,
+  setSelectedPlayers,
+}: Props) => {
   const [inputPlayers, setInputPlayers] = useState<User[]>([]);
-  const [selectedPlayers, setSelectedPlayers] = useState<User[]>([]);
   const [query, setQuery] = useState("");
   const [focused, setFocused] = useState(false);
   const input = useRef<HTMLInputElement | null>(null);
@@ -47,8 +50,6 @@ const Combobox: React.FC = () => {
       setInputPlayers(await getInputPlayers(inputValue, selectedPlayers));
     }, 300),
   });
-
-  // TODO: write a removeFromArray function for delete functionality
 
   useEffect(() => {
     async function fetchData(): Promise<void> {
@@ -70,15 +71,20 @@ const Combobox: React.FC = () => {
       setQuery("");
       selectItem(null);
     }
-  }, [selectItem, selectedItem, selectedPlayers]);
+  }, [selectItem, selectedItem, selectedPlayers, setSelectedPlayers]);
+
+  const onDelete = (user: User): void => {
+    setSelectedPlayers(
+      selectedPlayers.filter((selectedPlayer: User) => selectedPlayer !== user)
+    );
+  };
 
   return (
     <div className="container  w-4/5 mt-3">
       <div className="relative">
-        {/* <pre className="text-xs">
-          selected: {JSON.stringify(selectedPlayers)}
-        </pre> */}
-        <Card text="hello" onDelete={() => console.log("deleting")} />
+        {selectedPlayers.map((user) => (
+          <Card text={user.name} onDelete={() => onDelete(user)} />
+        ))}
 
         <div>
           <div {...getComboboxProps()}>

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@hookform/resolvers": "^1.0.0",
     "@prisma/client": "2.8.0",
     "@sendgrid/mail": "^7.4.0",
-    "autoprefixer": "9.8.6",
+    "autoprefixer": "^9.8.6",
     "db-migrate": "^0.11.11",
     "db-migrate-base": "^2.3.0",
     "downshift": "^6.0.6",

--- a/pages/admin/invite/new.tsx
+++ b/pages/admin/invite/new.tsx
@@ -10,6 +10,7 @@ import { AdminCreateUserDTO } from "pages/api/admin/users/create";
 import React, { useState } from "react";
 import { useForm } from "react-hook-form";
 import Combobox from "components/Combobox";
+import { User } from "@prisma/client";
 
 type AdminInviteFormValues = {
   firstName: string;
@@ -41,6 +42,7 @@ const AdminNewInvitePage: React.FC = () => {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
   const [roleChosen, setRoleChosen] = useState("");
+  const [selectedPlayers, setSelectedPlayers] = useState<User[]>([]);
 
   const { errors, register, handleSubmit } = useForm<AdminInviteFormValues>({
     resolver: joiResolver(AdminInviteFormSchema),
@@ -63,6 +65,8 @@ const AdminNewInvitePage: React.FC = () => {
           email: values.email,
           name: `${values.firstName} ${values.lastName}`,
           phoneNumber: values.phoneNumber,
+          role: values.role,
+          linkedPlayers: selectedPlayers.map((user) => user.id),
         } as AdminCreateUserDTO),
       });
       if (!response.ok) {
@@ -194,7 +198,10 @@ const AdminNewInvitePage: React.FC = () => {
                     }
                   })()}
                 </p>
-                <Combobox />
+                <Combobox
+                  selectedPlayers={selectedPlayers}
+                  setSelectedPlayers={setSelectedPlayers}
+                />
               </FormField>
             </div>
           </fieldset>

--- a/pages/api/admin/viewingPermissions/create.ts
+++ b/pages/api/admin/viewingPermissions/create.ts
@@ -8,7 +8,6 @@ import { adminOnlyHandler } from "../helpers";
 const prisma = new PrismaClient();
 
 export type ViewingPermissionDTO = {
-  // id: number;
   viewerId: number;
   vieweeId: number;
   relationshipType: string;


### PR DESCRIPTION
# Finishing up the player association flow 

- Combobox with cards that have removal abilities
- Updated endpoint to create corresponding new viewing permissions upon submitting form


## How to Test/Use PR feature

- Go to http://localhost:3000/admin/invite/new
- Select mentor, parent, or donor as role in order to see the Linked Players options
- Search, add, and remove players
- Press submit
- Check the database for 1) a newly created mentor/parent/donor and 2) new viewing permissions for each player

## PR Checklist

Does your branch (check if true):
- [x] work when you run `yarn build`?
- ~~due to the [non-null argument type for `selectItem`](https://github.com/calblueprint/ogsc/pull/54/commits/ee17c5d4cb889fb79c3fb964823b8e572e419c27#diff-68d1c6cb11ee54707043a5e5746e3fa051b0cfed4b9ebb2724940d91a796ceaaL71) function (part of Downshift Combobox)—not sure how to handle this, @sydbui also has this issue~~
- ~~maybe we can use [reset](https://github.com/downshift-js/downshift/pull/1149)?~~ yes reset works! 
- [x] successfully run `yarn:db-migrate up` without yielding any errors?
- [x] successfully run `yarn prisma introspect` without yielding any errors?
- [x] successfully run `yarn dev` and support all changes that your branch intends to perform?



## Screenshots
Combobox search
<img width="1395" alt="Screen Shot 2020-11-20 at 1 09 56 AM" src="https://user-images.githubusercontent.com/34170094/99781763-1e4da780-2acd-11eb-826b-40a1a715b5c4.png">

Player cards with ability to remove
<img width="1420" alt="Screen Shot 2020-11-20 at 1 10 40 AM" src="https://user-images.githubusercontent.com/34170094/99781842-37eeef00-2acd-11eb-8b53-a59a1709b95c.png">

CC: @erinysong
