### PR TITLE
Add IntegerWithComment, FloatWithComment types for GPA and engagement

### DIFF
--- a/bin/seed-database.ts
+++ b/bin/seed-database.ts
@@ -138,15 +138,27 @@ export default async function seedDatabase(): Promise<void> {
             create: [
               ...generateFieldsAcrossTimestamps(
                 ProfileFieldKey.AcademicEngagementScore,
-                () => Faker.random.number(10)
+                () =>
+                  JSON.stringify({
+                    comment: Faker.lorem.lines(1),
+                    value: Faker.random.number(10),
+                  })
               ),
               ...generateFieldsAcrossTimestamps(
                 ProfileFieldKey.AdvisingScore,
-                () => Faker.random.number(10)
+                () =>
+                  JSON.stringify({
+                    comment: Faker.lorem.lines(1),
+                    value: Faker.random.number(10),
+                  })
               ),
               ...generateFieldsAcrossTimestamps(
                 ProfileFieldKey.AthleticScore,
-                () => Faker.random.number(10)
+                () =>
+                  JSON.stringify({
+                    comment: Faker.lorem.lines(1),
+                    value: Faker.random.number(10),
+                  })
               ),
               ...generateFieldsAcrossTimestamps(
                 ProfileFieldKey.BioAboutMe,
@@ -180,10 +192,13 @@ export default async function seedDatabase(): Promise<void> {
                 () => Faker.lorem.lines(2)
               ),
               ...generateFieldsAcrossTimestamps(ProfileFieldKey.GPA, () =>
-                Faker.random.float({
-                  min: 2,
-                  max: 4,
-                  precision: 0.01,
+                JSON.stringify({
+                  comment: Faker.lorem.lines(1),
+                  value: Faker.random.float({
+                    min: 2,
+                    max: 4,
+                    precision: 0.01,
+                  }),
                 })
               ),
               ...generateFieldsAcrossTimestamps(

--- a/components/Player/ValueHistoryView.tsx
+++ b/components/Player/ValueHistoryView.tsx
@@ -29,6 +29,8 @@ type NumericProfileFields = Exclude<
     [K in ProfileFieldKey]: ProfileFieldValues[K] extends
       | ProfileFieldValue.Integer
       | ProfileFieldValue.Float
+      | ProfileFieldValue.IntegerWithComment
+      | ProfileFieldValue.FloatWithComment
       ? K
       : never;
   }[ProfileFieldKey],
@@ -114,13 +116,21 @@ const ValueHistoryView: React.FC<Props> = ({
   const [startDate, endDate] = IntervalWindowBoundaries[intervalWindow];
 
   const deserializedValues = values.map(
-    (field: IProfileField<NumericProfileFields>) => ({
-      ...field,
-      value: deserializeProfileFieldValue<ProfileField, NumericProfileFields>(
-        field
-      ),
-      createdAt: new Date(field.createdAt),
-    })
+    (field: IProfileField<NumericProfileFields>) => {
+      const deserialized = deserializeProfileFieldValue<
+        ProfileField,
+        NumericProfileFields
+      >(field);
+      return {
+        ...field,
+        ...(typeof deserialized === "number"
+          ? {}
+          : { comment: deserialized?.comment }),
+        value:
+          typeof deserialized === "number" ? deserialized : deserialized?.value,
+        createdAt: new Date(field.createdAt),
+      };
+    }
   );
   const filteredValues = deserializedValues.filter(({ createdAt }) =>
     startDate && endDate
@@ -223,7 +233,7 @@ const ValueHistoryView: React.FC<Props> = ({
                   })}
                 </td>
                 <td className="w-3/12">{field.value}</td>
-                <td />
+                <td>{field.comment}</td>
               </tr>
             ))}
           </tbody>

--- a/interfaces/user.ts
+++ b/interfaces/user.ts
@@ -64,13 +64,16 @@ export enum ProfileFieldValue {
   URL = "url",
   Integer = "integer",
   Float = "float",
+  IntegerWithComment = "integer_with_comment",
+  FloatWithComment = "float_with_comment",
   TimeElapsed = "time_elapsed",
 }
 
 export const ProfileFieldValues = <const>{
-  [ProfileFieldKey.AcademicEngagementScore]: ProfileFieldValue.Integer,
-  [ProfileFieldKey.AdvisingScore]: ProfileFieldValue.Integer,
-  [ProfileFieldKey.AthleticScore]: ProfileFieldValue.Integer,
+  [ProfileFieldKey.AcademicEngagementScore]:
+    ProfileFieldValue.IntegerWithComment,
+  [ProfileFieldKey.AdvisingScore]: ProfileFieldValue.IntegerWithComment,
+  [ProfileFieldKey.AthleticScore]: ProfileFieldValue.IntegerWithComment,
   [ProfileFieldKey.BioAboutMe]: ProfileFieldValue.Text,
   [ProfileFieldKey.BioFavoriteSubject]: ProfileFieldValue.Text,
   [ProfileFieldKey.BioHobbies]: ProfileFieldValue.Text,
@@ -79,7 +82,7 @@ export const ProfileFieldValues = <const>{
   [ProfileFieldKey.BioSiblings]: ProfileFieldValue.Text,
   [ProfileFieldKey.BMI]: ProfileFieldValue.Float,
   [ProfileFieldKey.DisciplinaryActions]: ProfileFieldValue.Text,
-  [ProfileFieldKey.GPA]: ProfileFieldValue.Float,
+  [ProfileFieldKey.GPA]: ProfileFieldValue.FloatWithComment,
   [ProfileFieldKey.HealthAndWellness]: ProfileFieldValue.Text,
   [ProfileFieldKey.Highlights]: ProfileFieldValue.URL,
   [ProfileFieldKey.IntroVideo]: ProfileFieldValue.URL,
@@ -91,11 +94,20 @@ export const ProfileFieldValues = <const>{
 };
 export type ProfileFieldValues = typeof ProfileFieldValues;
 
+type WithComment = {
+  /**
+   * An optional description to provide context about the value or to add commentary.
+   */
+  comment?: string;
+};
+
 export type ProfileFieldValueDeserializedTypes = {
   [ProfileFieldValue.Text]: string;
   [ProfileFieldValue.URL]: string;
   [ProfileFieldValue.Integer]: number;
+  [ProfileFieldValue.IntegerWithComment]: WithComment & { value: number };
   [ProfileFieldValue.Float]: number;
+  [ProfileFieldValue.FloatWithComment]: WithComment & { value: number };
   [ProfileFieldValue.TimeElapsed]: string;
 };
 


### PR DESCRIPTION
* Adds two new ProfileFieldValue types: IntegerWithComment, FloatWithComment
  * IntegerWithComment is now being used for all engagement score values
  * FloatWithComment is now being used for GPA values
* Updates seed to account for the new deserialized structure for these values:
  * `{ comment: "Some comment", value: 3 }`
* Updates ValueHistoryView component to read from `.value` in the case of WithComment profile fields and display comments in the table

## How to Test/Use PR feature

* Run `yarn db:seed` (required — there is no migration path for the old profile field values)
* Visit the player profile Engagement or GPA tabs
* Observe that comments appear in the rows of the table view

## PR Checklist

Does your branch (check if true):
- [x] work when you run `yarn build`?
- [x] successfully run `yarn:db-migrate up` without yielding any errors?
- [x] successfully run `yarn prisma introspect` without yielding any errors?
- [x] successfully run `yarn dev` and support all changes that your branch intends to perform?

## Screenshots

![image](https://user-images.githubusercontent.com/2977329/99898174-503d4600-2c54-11eb-988a-4e743fb56e9a.png)


CC: @erinysong
