### PR TITLE
Refactor Players Dashboard to Reflect Shannon's DB Changes

### DIFF
--- a/pages/api/admin/users/readMany.ts
+++ b/pages/api/admin/users/readMany.ts
@@ -23,6 +23,18 @@ export default async (
           isAdmin: true,
         },
       };
+    } else if (userRole === "Players") {
+      filterArgs = {
+        where: {
+          viewerPermissions: {
+            some: {
+              relationship_type: {
+                equals: `Player`,
+              },
+            },
+          },
+        },
+      };
     } else {
       filterArgs = {
         where: {

--- a/pages/api/admin/users/search/[phrase].ts
+++ b/pages/api/admin/users/search/[phrase].ts
@@ -18,7 +18,7 @@ export default async (
         },
         viewedByPermissions: {
           some: {
-            relationship_type: "player",
+            relationship_type: "Player",
           },
         },
       },

--- a/pages/api/admin/users/search/index.ts
+++ b/pages/api/admin/users/search/index.ts
@@ -17,7 +17,7 @@ export default async (
       where: {
         viewedByPermissions: {
           some: {
-            relationship_type: "player",
+            relationship_type: "Player",
           },
         },
       },

--- a/pages/users/signUp/index.tsx
+++ b/pages/users/signUp/index.tsx
@@ -163,7 +163,7 @@ const UserSignUpPageOne: React.FC = () => {
               </p>
               <div className="mb-2 flex ">
                 <Button
-                  className="button-primary text-base px-10 py-2 "
+                  className="button-primary text-base px-10 py-2"
                   type="submit"
                 >
                   Next step &#x2192;

--- a/pages/users/signUp/index.tsx
+++ b/pages/users/signUp/index.tsx
@@ -158,7 +158,8 @@ const UserSignUpPageOne: React.FC = () => {
             <div className="flex mt-24 mb-32 justify-between align-middle">
               {/* TODO: link user login page */}
               <p className="text-base">
-                Already have an account? <b>Login here.</b>
+                Already have an account?{" "}
+                <b className="text-blue">Login here.</b>
               </p>
               <div className="mb-2 flex ">
                 <Button


### PR DESCRIPTION
# Refactor Players Dashboard to Reflect Shannon's DB Changes

The following PR modifies the players dashboard and the players sub-component of the users dashboard to pull all of the players in accordance to Shannon's database changes that give each player user the user role of "Player".

Minor style fix has also been made in which the focus text of sign-up was changed to blue.

## How to Test/Use PR feature

Go to /admin/users and navigate to the players tab. The dashboard should now include all player users.The same results should appear on the /admin/players tab.

The user should also now be able to successfully access all players when adding player associations to the combobox component when adding new player profile accesses to a user.

## PR Checklist

Does your branch (check if true):
[X] work when you run `yarn build`?
[X] successfully run `yarn:db-migrate up` without yielding any errors?
[X] successfully run `yarn prisma introspect` without yielding any errors?
[X] successfully run `yarn dev` and support all changes that your branch intends to perform?

## Related PRs

_Optional - any related PRs you're waiting on, or PRs that will conflict, etc_

## Migrations

_Optional - if you added anything to the database through migration(s)_

## Screenshots
![image](https://user-images.githubusercontent.com/16397068/100492278-65e0be80-30df-11eb-8fe0-08c2e2c91b1e.png)
![image](https://user-images.githubusercontent.com/16397068/100492284-6aa57280-30df-11eb-979a-73da40b5b086.png)

![image](https://user-images.githubusercontent.com/16397068/100492269-5eb9b080-30df-11eb-89b2-2b9bc93fd98e.png)

CC: @erinysong
