### PR TITLE
Update to viewing_permissions non-null properties

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -82,11 +82,11 @@ model UserInvite {
 
 model ViewingPermission {
   id                Int     @id @default(autoincrement())
-  viewer_id         Int
+  viewer_id         Int?
   viewee_id         Int?
   relationship_type String?
   viewee            User?   @relation("UsersToViewees", fields: [viewee_id], references: [id])
-  viewer            User    @relation("UsersToViewers", fields: [viewer_id], references: [id])
+  viewer            User?   @relation("UsersToViewers", fields: [viewer_id], references: [id])
 
   @@map("viewing_permissions")
 }


### PR DESCRIPTION
My DB state was a bit different due to some work on the viewing permissions rename. I reset my DB state and found that this line may cause diffs on introspection from a correctly-built DB.

## How to Test/Use PR feature

* Verify that `yarn build` passes.

## PR Checklist

Does your branch (check if true):
- [x] work when you run `yarn build`?
- [x] successfully run `yarn:db-migrate up` without yielding any errors?
- [x] successfully run `yarn prisma introspect` without yielding any errors?
- [x] successfully run `yarn dev` and support all changes that your branch intends to perform?

## Related PRs

* #78 — original hotfix

CC: @erinysong
