### PR TITLE
Fixed multiple user invite sent bug & turn form into modal

### DIFF
--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -2,12 +2,15 @@ import React from "react";
 
 type Props = React.PropsWithChildren<{
   open?: boolean;
+  className: string;
 }>;
 
-const Modal: React.FC<Props> = ({ children, open }: Props) => {
+const Modal: React.FC<Props> = ({ children, open, className }: Props) => {
   return open ? (
     <div className="absolute top-0 left-0 w-screen h-screen bg-dark bg-opacity-50 flex justify-center items-center">
-      <div className="bg-white rounded w-1/2 px-10 pt-12 pb-8">{children}</div>
+      <div className={`bg-white rounded px-10 pt-12 pb-8 ${className}`}>
+        {children}
+      </div>
     </div>
   ) : null;
 };

--- a/components/Player/PlayerForm/AddAbsences.tsx
+++ b/components/Player/PlayerForm/AddAbsences.tsx
@@ -83,7 +83,9 @@ const AddAbsencesField: React.FC<Props> = ({
 
   return (
     <fieldset>
-      <div className="border border-border rounded-lg p-10">
+      <p className="text-2xl font-semibold mb-3">Add Absence</p>
+      <hr className="pb-8" />
+      <div>
         <p className="text-sm font-semibold mb-3">Absence Category</p>
         <DateComboBox
           items={["School", "Advising", "Athletic"]}

--- a/components/Player/PlayerForm/AddGPAField.tsx
+++ b/components/Player/PlayerForm/AddGPAField.tsx
@@ -50,7 +50,9 @@ const GPAScoreField: React.FC<Props> = ({
 
   return (
     <fieldset>
-      <div className="border border-border rounded-lg p-10">
+      <p className="text-2xl font-semibold mb-3">Add Grade Point Average</p>
+      <hr className="pb-8" />
+      <div>
         <p className="text-sm font-semibold mb-3">Quarter GPA</p>
         <input
           type="text"
@@ -60,7 +62,7 @@ const GPAScoreField: React.FC<Props> = ({
           onChange={(event) => SetGPA(event.target.value)}
         />
         <p className="text-sm font-semibold mb-3 mt-10">Month/Year</p>
-        <div className="grid grid-cols-5 mb-10">
+        <div className="grid grid-cols-4 mb-10">
           <DateComboBox
             items={months}
             placeholder="Month"

--- a/components/Player/PlayerForm/AddScoreField.tsx
+++ b/components/Player/PlayerForm/AddScoreField.tsx
@@ -70,7 +70,9 @@ const AddScoreField: React.FC<Props> = ({
 
   return (
     <fieldset>
-      <div className="border border-border rounded-lg p-10">
+      <p className="text-2xl font-semibold mb-3">Add Engagement Score</p>
+      <hr className="pb-8" />
+      <div>
         <p className="text-sm font-semibold mb-3">Score Category</p>
         <DateComboBox
           items={["School", "Advising", "Athletic"]}
@@ -86,7 +88,7 @@ const AddScoreField: React.FC<Props> = ({
           onChange={(event) => SetScore(event.target.value)}
         />
         <p className="text-sm font-semibold mb-3 mt-10">Month/Year</p>
-        <div className="grid grid-cols-5 mb-10">
+        <div className="grid grid-cols-4 mb-10">
           <DateComboBox
             items={months}
             placeholder="Month"

--- a/components/Player/PlayerForm/DisciplinaryField.tsx
+++ b/components/Player/PlayerForm/DisciplinaryField.tsx
@@ -55,7 +55,9 @@ const DAScoreField: React.FC<Props> = ({
 
   return (
     <fieldset>
-      <div className="border border-border rounded-lg p-10">
+      <p className="text-2xl font-semibold mb-3">Add Disciplinary Action</p>
+      <hr className="pb-8" />
+      <div>
         <p className="text-sm font-semibold mb-3">
           Nature of Disciplinary Action
         </p>

--- a/pages/[role]/players/[id].tsx
+++ b/pages/[role]/players/[id].tsx
@@ -83,7 +83,7 @@ const PlayerProfilePage: React.FunctionComponent<Props> = ({
             </p>
           </div>
         </div>
-        <Modal open={showModal}>
+        <Modal className="w-2/5" open={showModal}>
           <h1 className="text-dark text-3xl font-medium mb-2">
             Dashboard Created!
           </h1>

--- a/pages/admin/invite/index.tsx
+++ b/pages/admin/invite/index.tsx
@@ -20,7 +20,7 @@ const AdminInvitePage: React.FC = () => {
           <UserRequestsTable />
         </div>
       </div>
-      <Modal open={Boolean(router.query.success)}>
+      <Modal className="w-2/5" open={Boolean(router.query.success)}>
         <h1 className="text-dark text-3xl font-medium mb-2">Invite Sent!</h1>
         <p className="text-dark mb-10">
           Your invitee will have ? days to accept their invite.

--- a/pages/admin/players/playerForm/academics.tsx
+++ b/pages/admin/players/playerForm/academics.tsx
@@ -14,6 +14,7 @@ import { totalScore } from "pages/admin/players/playerForm/engagement";
 import Card from "components/Card";
 import Icon from "components/Icon";
 import { formatText, formatDA } from "components/Player/PlayerForm/FormItems";
+import Modal from "components/Modal";
 import type { PlayerProfileFormValues } from ".";
 
 export type AcademicFormValues = Pick<
@@ -104,13 +105,13 @@ const UserSignUpPageOne: React.FC = () => {
               >
                 Add Grade Point Average
               </Button>
-              {hiddenGPA ? (
+              <Modal className="w-2/3" open={hiddenGPA}>
                 <GPAScoreField
                   setHidden={setHiddenGPA}
                   listGPA={listGPA}
                   setListGPA={setListGPA}
                 />
-              ) : null}
+              </Modal>
               <p className="text-sm font-semibold pb-3 pt-10">
                 Disciplinary Actions
               </p>
@@ -131,13 +132,13 @@ const UserSignUpPageOne: React.FC = () => {
               >
                 Add Disciplinary Actions
               </Button>
-              {hiddenDA ? (
+              <Modal className="w-2/3" open={hiddenDA}>
                 <DisciplinaryField
                   setHidden={setHiddenDA}
                   DisciplinaryActions={DisciplinaryActionList}
                   SetDisciplinaryActions={SetDisciplinaryActions}
                 />
-              ) : null}
+              </Modal>
               {error && <p className="text-red-600 text-sm">{error}</p>}
               <hr className="border-unselected border-opacity-50 my-16" />
               <div className="flex mb-32">

--- a/pages/admin/players/playerForm/attendence.tsx
+++ b/pages/admin/players/playerForm/attendence.tsx
@@ -12,6 +12,7 @@ import PlayerFormLayout from "components/Player/PlayerFormLayout";
 import Icon from "components/Icon";
 import Card from "components/Card";
 import { formatAbsence } from "components/Player/PlayerForm/FormItems";
+import Modal from "components/Modal";
 
 export type AbsenceFormValues = {
   schoolAbsences: string[];
@@ -134,7 +135,7 @@ const UserSignUpPageOne: React.FC = () => {
               >
                 Add Absence
               </Button>
-              {hidden ? (
+              <Modal className="w-2/3" open={hidden}>
                 <AddAbsences
                   setHidden={setHidden}
                   advisingAbsences={advisingAbsences}
@@ -144,7 +145,7 @@ const UserSignUpPageOne: React.FC = () => {
                   setAthleticAbsences={SetAthleticAbsences}
                   setSchoolAbsences={SetSchoolAbsences}
                 />
-              ) : null}
+              </Modal>
               {error && <p className="text-red-600 text-sm">{error}</p>}
               <hr className="border-unselected border-opacity-50 my-16" />
               <div className="flex mb-32">

--- a/pages/admin/players/playerForm/engagement.tsx
+++ b/pages/admin/players/playerForm/engagement.tsx
@@ -12,6 +12,7 @@ import AddScoreField from "components/Player/PlayerForm/AddScoreField";
 import Card from "components/Card";
 import Icon from "components/Icon";
 import { formatText } from "components/Player/PlayerForm/FormItems";
+import Modal from "components/Modal";
 import type { PlayerProfileFormValues } from ".";
 
 export type EngagementFormValues = Pick<
@@ -151,7 +152,7 @@ const UserSignUpPageOne: React.FC = () => {
               >
                 Add Engagement Score
               </Button>
-              {hidden ? (
+              <Modal className="w-2/3" open={hidden}>
                 <AddScoreField
                   setHidden={setHidden}
                   advisingScores={advisingScores}
@@ -161,7 +162,7 @@ const UserSignUpPageOne: React.FC = () => {
                   setSchoolScores={SetSchoolScores}
                   setAthleticScores={SetAthleticScores}
                 />
-              ) : null}
+              </Modal>
               {error && <p className="text-red-600 text-sm">{error}</p>}
               <hr className="border-unselected border-opacity-50 my-16" />
               <div className="flex mb-32">


### PR DESCRIPTION
Turn form fields into modal & Fixed multiple invites sent bug

- fixed bug of a double user invite sent within form
- turned the form fields for attendance, engagement, gpa, and disciplinary actions into modals

## TODO (if applicable)

_Checklist of any action items that still must be done on this PR_

## How to Test/Use PR feature

_Describe how to use and/or access the feature that your PR handles_

## PR Checklist

Does your branch (check if true):
- [] work when you run `yarn build`?
- [x] successfully run `yarn:db-migrate up` without yielding any errors?
- [x] successfully run `yarn prisma introspect` without yielding any errors?
- [x] successfully run `yarn dev` and support all changes that your branch intends to perform?

## Related PRs

_Optional - any related PRs you're waiting on, or PRs that will conflict, etc_

## Migrations

_Optional - if you added anything to the database through migration(s)_

## Screenshots

<img width="1376" alt="Screen Shot 2020-11-29 at 4 11 09 PM" src="https://user-images.githubusercontent.com/57571626/100557356-8171d380-325d-11eb-8081-832b2c2268ce.png">


CC: @erinysong
