### PR TITLE
Implement access control by user role

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["next/babel"],
+  "plugins": ["superjson-next"]
+}

--- a/components/Player/Profile.tsx
+++ b/components/Player/Profile.tsx
@@ -284,7 +284,7 @@ const Profile: React.FunctionComponent<Props> = ({ player }: Props) => {
   );
   return (
     <div>
-      <div className="flex flex-row justify-between text-sm text-center">
+      <div className="flex flex-row text-sm text-center">
         {Object.values(ProfileCategory)
           .filter(
             (category: ProfileCategory) =>
@@ -297,7 +297,7 @@ const Profile: React.FunctionComponent<Props> = ({ player }: Props) => {
             <button
               key={category}
               type="button"
-              className={`navigation-tab ${
+              className={`navigation-tab mr-8 ${
                 selectedCategory === category
                   ? "navigation-tab-highlighted"
                   : ""

--- a/lib/access/definitions.ts
+++ b/lib/access/definitions.ts
@@ -1,0 +1,79 @@
+import { IPlayer, IUser, ProfileFieldKey, UserRoleType } from "interfaces";
+import { AccessValue, ProfileAccessDefinition } from "./types";
+
+const isSharedPlayerProfile: AccessValue = (
+  player: IPlayer,
+  upstreamUser: IUser
+): boolean => upstreamUser.defaultRole.relatedPlayerIds.includes(player.id);
+
+const isOwnPlayerProfile: AccessValue = (
+  player: IPlayer,
+  user: IUser
+): boolean => player.id === user.id;
+
+/**
+ * The standard access that all users share, minimally.
+ */
+const standardReadAccess = {
+  [ProfileFieldKey.BioAboutMe]: { read: true },
+  [ProfileFieldKey.BioFavoriteSubject]: { read: true },
+  [ProfileFieldKey.BioMostDifficultSubject]: { read: true },
+  [ProfileFieldKey.BioHobbies]: { read: true },
+  [ProfileFieldKey.BioParents]: { read: true },
+  [ProfileFieldKey.BioSiblings]: { read: true },
+  [ProfileFieldKey.IntroVideo]: { read: true },
+  [ProfileFieldKey.Highlights]: { read: true },
+};
+
+/**
+ * A map of UserRoleTypes (except for Admins, who by default have full access) to
+ * ProfileAccessDefinitions.
+ */
+const ProfileAccessDefinitionsByRole: Record<
+  Exclude<UserRoleType, "Admin">,
+  ProfileAccessDefinition
+> = {
+  [UserRoleType.Donor]: standardReadAccess,
+  [UserRoleType.Mentor]: {
+    ...standardReadAccess,
+    [ProfileFieldKey.GPA]: { read: isSharedPlayerProfile },
+    [ProfileFieldKey.BMI]: { read: isSharedPlayerProfile },
+    [ProfileFieldKey.PacerTest]: { read: isSharedPlayerProfile },
+    [ProfileFieldKey.MileTime]: { read: isSharedPlayerProfile },
+    [ProfileFieldKey.Situps]: { read: isSharedPlayerProfile },
+    [ProfileFieldKey.Pushups]: { read: isSharedPlayerProfile },
+    [ProfileFieldKey.HealthAndWellness]: { read: isSharedPlayerProfile },
+  },
+  [UserRoleType.Parent]: {
+    ...standardReadAccess,
+    [ProfileFieldKey.BioAboutMe]: { read: true, write: isSharedPlayerProfile },
+    [ProfileFieldKey.BioFavoriteSubject]: {
+      read: true,
+      write: isSharedPlayerProfile,
+    },
+    [ProfileFieldKey.BioMostDifficultSubject]: {
+      read: true,
+      write: isSharedPlayerProfile,
+    },
+    [ProfileFieldKey.BioHobbies]: { read: true, write: isSharedPlayerProfile },
+    [ProfileFieldKey.BioParents]: { read: true, write: isSharedPlayerProfile },
+    [ProfileFieldKey.BioSiblings]: { read: true, write: isSharedPlayerProfile },
+  },
+  [UserRoleType.Player]: {
+    ...standardReadAccess,
+    [ProfileFieldKey.BioAboutMe]: { read: true, write: isOwnPlayerProfile },
+    [ProfileFieldKey.BioFavoriteSubject]: {
+      read: true,
+      write: isOwnPlayerProfile,
+    },
+    [ProfileFieldKey.BioMostDifficultSubject]: {
+      read: true,
+      write: isOwnPlayerProfile,
+    },
+    [ProfileFieldKey.BioHobbies]: { read: true, write: isOwnPlayerProfile },
+    [ProfileFieldKey.BioParents]: { read: true, write: isOwnPlayerProfile },
+    [ProfileFieldKey.BioSiblings]: { read: true, write: isOwnPlayerProfile },
+  },
+};
+
+export default ProfileAccessDefinitionsByRole;

--- a/lib/access/definitions.ts
+++ b/lib/access/definitions.ts
@@ -15,6 +15,7 @@ const isOwnPlayerProfile: AccessValue = (
  * The standard access that all users share, minimally.
  */
 const standardReadAccess = {
+  [ProfileFieldKey.PlayerNumber]: { read: true },
   [ProfileFieldKey.BioAboutMe]: { read: true },
   [ProfileFieldKey.BioFavoriteSubject]: { read: true },
   [ProfileFieldKey.BioMostDifficultSubject]: { read: true },

--- a/lib/access/resolve.ts
+++ b/lib/access/resolve.ts
@@ -1,0 +1,25 @@
+import { IPlayer, IUser } from "interfaces/user";
+import { AccessValue } from "./types";
+
+export default function resolveAccessValue(
+  accessValue: AccessValue,
+  intent: "read" | "write",
+  player: IPlayer,
+  user: IUser
+): boolean {
+  switch (typeof accessValue) {
+    case "boolean":
+      return accessValue;
+    case "function":
+      return accessValue(player, user);
+    case "object": {
+      const resolvingValue = accessValue[intent];
+      if (resolvingValue !== undefined) {
+        return resolveAccessValue(resolvingValue, intent, player, user);
+      }
+      return false;
+    }
+    default:
+      return false;
+  }
+}

--- a/lib/access/types.ts
+++ b/lib/access/types.ts
@@ -1,0 +1,22 @@
+import { IPlayer, IUser, ProfileFieldKey } from "interfaces";
+
+type AccessValueBase = boolean | ((player: IPlayer, user: IUser) => boolean);
+export type AccessValue =
+  | AccessValueBase
+  | { read?: AccessValueBase; write?: AccessValueBase };
+
+/**
+ * A ProfileAccessDefinition specifies how a particular user should be able to interact with a
+ * player profile. Each access definition can specify a set of true/false values or functions
+ * to determine which ProfileFieldKeys a user has access to.
+ *
+ * @example
+ * const BioReadOnlyAccess: ProfileAccessDefinition = {
+ *  [ProfileFieldKey.BioAoutMe]: { read: true },
+ *  [ProfileFieldKey.BioFavoriteSubject]: { read: true },
+ *  // ...
+ * }
+ */
+export type ProfileAccessDefinition = Partial<
+  Record<ProfileFieldKey, AccessValue>
+>;

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "react": "16.14.0",
     "react-dom": "16.13.1",
     "react-hook-form": "^6.9.6",
+    "superjson": "^1.4.1",
     "tailwindcss": "^1.9.4",
     "victory": "^35.3.5"
   },
@@ -66,6 +67,7 @@
     "@typescript-eslint/eslint-plugin": "^4.8.2",
     "@typescript-eslint/parser": "^4.8.1",
     "babel-eslint": "^10.1.0",
+    "babel-plugin-superjson-next": "^0.1.8",
     "db-migrate-pg": "^1.2.2",
     "db-migrate-plugin-typescript": "ethanlee16/plugin-typescript",
     "eslint": "^7.10.0",

--- a/pages/[role]/players/[id].tsx
+++ b/pages/[role]/players/[id].tsx
@@ -1,13 +1,8 @@
 import { useState } from "react";
-import {
-  Absence,
-  PrismaClient,
-  ProfileField,
-  Role,
-  User,
-} from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
 import { NextPageContext } from "next";
 import { useRouter } from "next/router";
+import { getSession } from "next-auth/client";
 
 import DashboardLayout from "components/DashboardLayout";
 import PlayerProfile from "components/Player/Profile";
@@ -15,17 +10,12 @@ import Modal from "components/Modal";
 import Button from "components/Button";
 import sanitizeUser from "utils/sanitizeUser";
 import buildUserProfile from "utils/buildUserProfile";
+import filterPlayerProfileRead from "utils/filterPlayerProfileRead";
 import flattenUserRoles from "utils/flattenUserRoles";
+import { IPlayer } from "interfaces";
 
 type Props = {
-  player?: Omit<
-    User & {
-      absences: Absence[];
-      profileFields: ProfileField[];
-      roles: Role[];
-    },
-    "hashedPassword"
-  >;
+  player?: IPlayer;
 };
 
 export async function getServerSideProps(
@@ -41,15 +31,31 @@ export async function getServerSideProps(
       roles: true,
     },
   });
-
   if (user === null) {
     // TODO: Set statusCode to 404
     return { props: {} };
   }
 
+  const session = await getSession({ req: context.req });
+  if (!session) {
+    // TODO: Set statusCode to 401
+    return { props: {} };
+  }
+  const authenticatedUser = await prisma.user.findOne({
+    where: { email: session.user.email },
+    include: { roles: true },
+  });
+  if (!authenticatedUser) {
+    // TODO: Set statusCode to 401
+    return { props: {} };
+  }
+
   return {
     props: {
-      player: JSON.parse(JSON.stringify(sanitizeUser(user))),
+      player: filterPlayerProfileRead(
+        buildUserProfile(flattenUserRoles(sanitizeUser(user))),
+        flattenUserRoles(authenticatedUser)
+      ),
     },
   };
 }
@@ -64,7 +70,6 @@ const PlayerProfilePage: React.FunctionComponent<Props> = ({
   if (!player) {
     return <DashboardLayout>No player found</DashboardLayout>;
   }
-  const hydratedPlayer = flattenUserRoles(buildUserProfile(player));
 
   return (
     <DashboardLayout>
@@ -73,15 +78,15 @@ const PlayerProfilePage: React.FunctionComponent<Props> = ({
           <div className="picture flex mr-10">
             <img
               src="/placeholder-profile.png"
-              alt={hydratedPlayer.name || "player"}
+              alt={player.name || "player"}
               className="bg-button rounded-full max-w-full align-middle border-none w-24 h-24"
             />
           </div>
           <div className="player-info grid grid-rows-2">
-            <p className="pt-6 text-2xl font-semibold">{hydratedPlayer.name}</p>
+            <p className="pt-6 text-2xl font-semibold">{player.name}</p>
             <p className="pt-2 text-sm font-medium">
-              {hydratedPlayer.profile?.PlayerNumber.current &&
-                `#${hydratedPlayer.profile?.PlayerNumber.current}`}
+              {player.profile?.PlayerNumber?.current &&
+                `#${player.profile?.PlayerNumber.current}`}
             </p>
           </div>
         </div>
@@ -103,7 +108,7 @@ const PlayerProfilePage: React.FunctionComponent<Props> = ({
             </Button>
           </div>
         </Modal>
-        <PlayerProfile player={hydratedPlayer} />
+        <PlayerProfile player={player} />
       </div>
     </DashboardLayout>
   );

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -128,12 +128,6 @@ model Role {
   @@map("roles")
 }
 
-model seeds {
-  id     Int      @id @default(autoincrement())
-  name   String
-  run_on DateTime
-}
-
 enum ProfileFieldKey {
   AcademicEngagementScore @map("academic_engagement_score")
   AdvisingScore @map("advising_score")

--- a/utils/filterPlayerProfileRead.ts
+++ b/utils/filterPlayerProfileRead.ts
@@ -1,0 +1,37 @@
+import {
+  IPlayer,
+  IUser,
+  PlayerProfile,
+  ProfileFieldKey,
+  UserRoleType,
+} from "interfaces";
+import ProfileAccessDefinitionsByRole from "lib/access/definitions";
+import resolveAccessValue from "lib/access/resolve";
+
+const filterPlayerProfileRead = (
+  player: IPlayer,
+  user: IUser
+): Partial<PlayerProfile> | null => {
+  if (!player.profile) {
+    return null;
+  }
+  if (user.defaultRole.type === UserRoleType.Admin) {
+    return player.profile;
+  }
+  return Object.fromEntries(
+    Object.entries<PlayerProfile[ProfileFieldKey]>(
+      player.profile as PlayerProfile
+    ).filter(([fieldKey]: [string, PlayerProfile[ProfileFieldKey]]) => {
+      const accessValue =
+        ProfileAccessDefinitionsByRole[
+          user.defaultRole.type as Exclude<UserRoleType, "Admin">
+        ][fieldKey as ProfileFieldKey];
+      if (accessValue === undefined) {
+        return false;
+      }
+      return resolveAccessValue(accessValue, "read", player, user);
+    })
+  );
+};
+
+export default filterPlayerProfileRead;

--- a/utils/filterPlayerProfileRead.ts
+++ b/utils/filterPlayerProfileRead.ts
@@ -8,30 +8,29 @@ import {
 import ProfileAccessDefinitionsByRole from "lib/access/definitions";
 import resolveAccessValue from "lib/access/resolve";
 
-const filterPlayerProfileRead = (
-  player: IPlayer,
-  user: IUser
-): Partial<PlayerProfile> | null => {
-  if (!player.profile) {
-    return null;
+const filterPlayerProfileRead = (player: IPlayer, user: IUser): IPlayer => {
+  if (!player.profile || user.defaultRole.type === UserRoleType.Admin) {
+    return player;
   }
-  if (user.defaultRole.type === UserRoleType.Admin) {
-    return player.profile;
-  }
-  return Object.fromEntries(
-    Object.entries<PlayerProfile[ProfileFieldKey]>(
-      player.profile as PlayerProfile
-    ).filter(([fieldKey]: [string, PlayerProfile[ProfileFieldKey]]) => {
-      const accessValue =
-        ProfileAccessDefinitionsByRole[
-          user.defaultRole.type as Exclude<UserRoleType, "Admin">
-        ][fieldKey as ProfileFieldKey];
-      if (accessValue === undefined) {
-        return false;
-      }
-      return resolveAccessValue(accessValue, "read", player, user);
-    })
-  );
+
+  return {
+    ...player,
+    absences: undefined,
+    profile: Object.fromEntries(
+      Object.entries<PlayerProfile[ProfileFieldKey]>(
+        player.profile as PlayerProfile
+      ).filter(([fieldKey]: [string, PlayerProfile[ProfileFieldKey]]) => {
+        const accessValue =
+          ProfileAccessDefinitionsByRole[
+            user.defaultRole.type as Exclude<UserRoleType, "Admin">
+          ][fieldKey as ProfileFieldKey];
+        if (accessValue === undefined) {
+          return false;
+        }
+        return resolveAccessValue(accessValue, "read", player, user);
+      })
+    ),
+  };
 };
 
 export default filterPlayerProfileRead;

--- a/utils/filterPlayerProfileWrite.ts
+++ b/utils/filterPlayerProfileWrite.ts
@@ -1,0 +1,33 @@
+import {
+  ProfileFieldCreateWithoutUserInput,
+  ProfileFieldUpdateManyWithoutUserInput,
+} from "@prisma/client";
+import { IPlayer, IUser, UserRoleType } from "interfaces";
+import ProfileAccessDefinitionsByRole from "lib/access/definitions";
+import resolveAccessValue from "lib/access/resolve";
+
+const filterPlayerProfileWrite = (
+  player: IPlayer,
+  user: IUser,
+  profileFields: ProfileFieldUpdateManyWithoutUserInput
+): ProfileFieldUpdateManyWithoutUserInput => {
+  const filteredProfileFields: ProfileFieldUpdateManyWithoutUserInput = {};
+  if (profileFields.create) {
+    filteredProfileFields.create = (Array.isArray(profileFields.create)
+      ? profileFields.create
+      : [profileFields.create]
+    ).filter((fieldCreate: ProfileFieldCreateWithoutUserInput) => {
+      const accessValue =
+        ProfileAccessDefinitionsByRole[
+          user.defaultRole.type as Exclude<UserRoleType, "Admin">
+        ][fieldCreate.key];
+      if (accessValue === undefined) {
+        return false;
+      }
+      return resolveAccessValue(accessValue, "write", player, user);
+    });
+  }
+  return filteredProfileFields;
+};
+
+export default filterPlayerProfileWrite;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1927,6 +1927,14 @@ babel-plugin-dynamic-import-node@^2.3.3:
   dependencies:
     object.assign "^4.1.0"
 
+babel-plugin-superjson-next@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-superjson-next/-/babel-plugin-superjson-next-0.1.8.tgz#99e3aabf20ac0e7f095dcc160bb88d83d755aa17"
+  integrity sha512-XXCDSpwYqrLE3TyW00155fXSEW/vCheuxF32Hgot7bVaGO8fC6Z/97OFJqIcZ2+yOutoOjymkExyb9kVzmxsIw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.10.4"
+    hoist-non-react-statics "^3.3.2"
+
 babel-plugin-syntax-jsx@6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
@@ -4181,6 +4189,13 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
+hoist-non-react-statics@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
+
 hosted-git-info@^2.1.4:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
@@ -4888,6 +4903,11 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
+
+lodash-es@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
+  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
 
 lodash.debounce@^4.0.8:
   version "4.0.8"
@@ -6325,7 +6345,7 @@ react-hook-form@^6.9.6:
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.9.6.tgz#bbcdfa34a660edcdd160cba2d501583b0e3d60a9"
   integrity sha512-TyLqWHgFS1WLELDuUBvMWLHEzmR7aS7xOY+eOxMtS1w4jFhqF1xmHnMhJsbiFPSgC+OeTJ1Pc0U4K0y6cA7ERA==
 
-react-is@16.13.1, react-is@^16.13.1, react-is@^16.8.1:
+react-is@16.13.1, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -7240,6 +7260,14 @@ stylis@3.5.4:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
   integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
+
+superjson@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/superjson/-/superjson-1.4.1.tgz#c96501fc0cc32cc9cb25ecc3fb476db631eceba2"
+  integrity sha512-+PjOQNj7mW4I0t3KphIgwwQvQObd5Tc1DtUoIMj3iN7RXQyoWr2R8LXLtQw/UNEItSd0Al+qn0I/8yCnTXiAIw==
+  dependencies:
+    lodash "^4.17.20"
+    lodash-es "^4.17.15"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
* Creates lib/access structure for defining "profile access definitions," which refer to maps of profile field keys to true/false values (or functions that resolve to true/false values)
* Defines initial profile access definitions according to this spec: https://www.notion.so/User-Access-Wrapper-Functions-2b8763b81a3e4c4f815d065959bda929#d2bb6de79aa74337b1c83a3779595939
* Adds utils `filterPlayerProfileRead` and `filterPlayerProfileWrite` for wrapping around IPlayer/UserUpdateArgs across the app — these utils provide role-sensitive access control
* Updates player profile page to use `filterPlayerProfileRead` util
* Adds `superjson` and its Babel plugin for next as a dependency to the app — these libraries handle `getServerSideProps` serialization/deserialization that support types like Dates

## TODO

_(All to be addressed in follow-on PR[s])_
* Apply `filterPlayerProfileWrite` to all API surface areas that create or update profile field values
* Read from lib/access/definitions to determine what Edit states to make available to the authenticated user

## How to Test/Use PR feature

* Login as a donor. Visit a player profile (you may need to find the ID from Prisma Studio). Observe that only the Bio/Highlights tabs are visible.
* Login as a mentor. Find the matching player's ID (you may need to find the ID from Prisma Studio). Observe that for their matching mentored player: GPA, physical wellness details, bio, and highlights are visible. Observe that for another player that is not mentored by this user, only the bio and highlights tabs are visible.

## PR Checklist

Does your branch (check if true):
- [x] work when you run `yarn build`?
- [x] successfully run `yarn:db-migrate up` without yielding any errors?
- [x] successfully run `yarn prisma introspect` without yielding any errors?
- [x] successfully run `yarn dev` and support all changes that your branch intends to perform?

## Related PRs

* #92 — some parts of the UI may need to be updated to reflect role-sensitive access. Some API requests may need to be wrapped with `filterPlayerProfileWrite`.

## Screenshots

* Navigation tabs on player profile no longer use `justify-content: space-between`. This is because there are now a minimum of 2 tabs that will fill this area, causing confusing use of the space when the flex container uses `space-between`. The tabs have been updated to use `mr-8` instead:
<img src="https://user-images.githubusercontent.com/2977329/101262477-ead96280-36f3-11eb-984c-30f5517bee66.png" width="400">
<img src="https://user-images.githubusercontent.com/2977329/101262478-ef9e1680-36f3-11eb-96de-ebd5f8be8796.png" width="200">
<img src="https://user-images.githubusercontent.com/2977329/101262480-f9c01500-36f3-11eb-84f5-4cc23b85eebd.png" width="600">


CC: @erinysong
