### PR TITLE
More General Combobox Component

### DIFF
--- a/components/Combobox.tsx
+++ b/components/Combobox.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { useCombobox } from "downshift";
 import { User } from "@prisma/client";
 import debounce from "lodash.debounce";
+import { UserRoleLabel, UserRoleType } from "interfaces";
 import Button from "./Button";
 import Card from "./Card";
 
@@ -24,11 +25,13 @@ const getInputPlayers = async (
 type Props = React.PropsWithChildren<{
   selectedPlayers: User[];
   setSelectedPlayers: React.Dispatch<React.SetStateAction<User[]>>;
+  role: string;
 }>;
 
 const Combobox: React.FC<Props> = ({
   selectedPlayers,
   setSelectedPlayers,
+  role,
 }: Props) => {
   const [inputPlayers, setInputPlayers] = useState<User[]>([]);
   const [query, setQuery] = useState("");
@@ -81,6 +84,20 @@ const Combobox: React.FC<Props> = ({
 
   return (
     <div className="container  w-4/5 mt-3">
+      <p className={`text-xs font-normal mt-3 mb-3 `}>
+        {(() => {
+          switch (role) {
+            case UserRoleLabel[UserRoleType.Mentor]:
+              return "Mentors will have access to the full profile of players they are mentoring, including Engagement Scores, Academics, Attendance, and Physical Health information.";
+            case UserRoleLabel[UserRoleType.Parent]:
+              return "Parents will have access to the full profile of their children, including Engagement Scores, Academics, Attendance, and Physical Health information.";
+            case UserRoleLabel[UserRoleType.Donor]:
+              return "Donors will have access to extended profiles of players they’re sponsoring, including Engagement Scores, Academics, and Physical Health information.";
+            default:
+              return "error";
+          }
+        })()}
+      </p>
       <div className="relative">
         {selectedPlayers.map((user) => (
           <Card text={user.name} onDelete={() => onDelete(user)} />

--- a/pages/admin/invite/new.tsx
+++ b/pages/admin/invite/new.tsx
@@ -184,25 +184,10 @@ const AdminNewInvitePage: React.FC = () => {
                 name="linkedPlayers"
                 error="" // TODO: fix this
               >
-                <p
-                  className={`text-xs font-normal mt-3 mb-3 ${showCombobox()}`}
-                >
-                  {(() => {
-                    switch (roleChosen) {
-                      case UserRoleType.Mentor:
-                        return "Mentors will have access to the full profile of players they are mentoring, including Engagement Scores, Academics, Attendance, and Physical Health information.";
-                      case UserRoleType.Parent:
-                        return "Parents will have access to the full profile of their children, including Engagement Scores, Academics, Attendance, and Physical Health information.";
-                      case UserRoleType.Donor:
-                        return "Donors will have access to extended profiles of players they’re sponsoring, including Engagement Scores, Academics, and Physical Health information.";
-                      default:
-                        return "error";
-                    }
-                  })()}
-                </p>
                 <Combobox
                   selectedPlayers={selectedPlayers}
                   setSelectedPlayers={setSelectedPlayers}
+                  role={roleChosen}
                 />
               </FormField>
             </div>

--- a/pages/api/admin/users/create.ts
+++ b/pages/api/admin/users/create.ts
@@ -47,7 +47,7 @@ const handler = async (
               roles: {
                 create: linkedPlayers?.map((playerID: number) => ({
                   type: role,
-                  viewee: {
+                  relatedPlayer: {
                     connect: {
                       id: playerID,
                     },

--- a/pages/users/acceptInvite/acceptInvite2.tsx
+++ b/pages/users/acceptInvite/acceptInvite2.tsx
@@ -46,11 +46,9 @@ const UserAcceptInvitePageTwo: React.FC = () => {
   const [revealPassword, setRevealPassword] = useState(false);
   const [revealConfirmPassword, setRevealConfirmPassword] = useState(false);
 
-  const {
-    errors,
-    register,
-    handleSubmit,
-  } = useForm<UserAcceptInviteForm2Values>({
+  const { errors, register, handleSubmit } = useForm<
+    UserAcceptInviteForm2Values
+  >({
     resolver: joiResolver(UserAcceptInviteForm2Schema),
   });
   const { state, action } = useStateMachine(updateActionAcceptInvite);


### PR DESCRIPTION
# Generalizing Combobox Component

- Generalizing combobox from the invites form for reusability in the user request pages
- Props now include `role` to generate the subtext (`selectedPlayers, setSelectedPlayers` still being passed in)
- Small create endpoint fix from the user role refactor

## How to Test/Use PR feature

- visit http://localhost:3000/admin/invite/new (and soon user request pages)

## PR Checklist

Does your branch (check if true):
- [x] work when you run `yarn build`?
- [x] successfully run `yarn:db-migrate up` without yielding any errors?
- [x] successfully run `yarn prisma introspect` without yielding any errors?
- [x] successfully run `yarn dev` and support all changes that your branch intends to perform?

## Related PRs

@christopher-grey ready for use in user requests!

CC: @erinysong
