### PR TITLE
refactor deleting users and fix bugs in delete

### DIFF
--- a/pages/admin/user/[id].tsx
+++ b/pages/admin/user/[id].tsx
@@ -1,4 +1,4 @@
-import { useRouter } from "next/router";
+import { NextRouter, useRouter } from "next/router";
 import DashboardLayout from "components/DashboardLayout";
 import React, { useState, useEffect } from "react";
 import Icon from "components/Icon";
@@ -9,6 +9,7 @@ import Joi from "joi";
 import { joiResolver } from "@hookform/resolvers/joi";
 import { UpdateUserDTO } from "pages/api/admin/users/update";
 import { useForm } from "react-hook-form";
+import { DeleteUserDTO } from "pages/api/admin/users/delete";
 
 interface AdminEditUserFormValues {
   firstName: string;
@@ -23,6 +24,13 @@ interface EditUserProps {
   isEditing: boolean;
   setIsEditing: React.Dispatch<React.SetStateAction<boolean>>;
   setUser: (user: IUser) => void;
+}
+
+interface DeleteConfirmationProps {
+  user?: IUser;
+  isDeleting: boolean;
+  setIsDeleting: React.Dispatch<React.SetStateAction<boolean>>;
+  router: NextRouter;
 }
 
 type ModalProps = React.PropsWithChildren<{
@@ -50,6 +58,52 @@ const AdminEditUserFormSchema = Joi.object<AdminEditUserFormValues>({
     .valid(...Object.values(UserRoleType))
     .required(),
 });
+
+const DeleteConfirmation: React.FunctionComponent<DeleteConfirmationProps> = ({
+  user,
+  isDeleting,
+  setIsDeleting,
+  router,
+}) => {
+  async function onDelete(): Promise<void> {
+    const response = await fetch(`/api/admin/users/${user?.id}`, {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({
+        id: user?.id,
+      } as DeleteUserDTO),
+    });
+    if (!response.ok) {
+      throw await response.json();
+    }
+    setIsDeleting(false);
+    router.push("/admin/users");
+  }
+  return (
+    <Modal open={Boolean(isDeleting)}>
+      <p>Are you sure you want to delete this user?</p>
+      <div className="mb-2 flex">
+        <Button
+          className="button-primary px-10 py-2 mr-5"
+          onClick={() => {
+            onDelete();
+          }}
+        >
+          Delete
+        </Button>
+        <Button
+          className="button-hollow px-10 py-2"
+          onClick={() => {
+            setIsDeleting(false);
+          }}
+        >
+          Cancel
+        </Button>
+      </div>
+    </Modal>
+  );
+};
 
 const EditUser: React.FunctionComponent<EditUserProps> = ({
   user,
@@ -100,6 +154,7 @@ const EditUser: React.FunctionComponent<EditUserProps> = ({
       setIsEditing(false);
     }
   }
+
   return (
     <Modal open={Boolean(isEditing)}>
       <div className="mx-16 mt-24">
@@ -252,6 +307,7 @@ const EditUser: React.FunctionComponent<EditUserProps> = ({
 const UserProfile: React.FunctionComponent = () => {
   const [user, setUser] = useState<IUser>();
   const [isEditing, setIsEditing] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
   const router = useRouter();
   const { id } = router.query;
 
@@ -315,7 +371,26 @@ const UserProfile: React.FunctionComponent = () => {
             <p className="text-blue mr-20 w-24">Menteed Players</p>
             <p>List</p>
           </div>
+          <p className="text-lg font-semibold pb-10 pt-16">Account Changes</p>
+          <p className="font-semibold text-sm pb-3">Close Account</p>
+          <p className="text-sm font-normal">
+            Delete this user&apos;s account and account data
+          </p>
+          <Button
+            className="button-primary mt-7 mb-52 mr-5 text-danger bg-danger-muted"
+            onClick={() => {
+              setIsDeleting(true);
+            }}
+          >
+            Close Account
+          </Button>
         </div>
+        {DeleteConfirmation({
+          user,
+          isDeleting,
+          setIsDeleting,
+          router,
+        })}
         <EditUser
           user={user}
           isEditing={isEditing}

--- a/pages/api/admin/users/delete.ts
+++ b/pages/api/admin/users/delete.ts
@@ -25,6 +25,18 @@ const handler = async (
     await prisma.userInvite.deleteMany({
       where: { user_id: userId },
     });
+    await prisma.role.deleteMany({
+      where: { OR: [{ userId }, { relatedPlayerId: userId }] },
+    });
+    await prisma.absence.deleteMany({
+      where: { userId },
+    });
+    await prisma.profileField.deleteMany({
+      where: { userId },
+    });
+    await prisma.resetPassword.deleteMany({
+      where: { userId },
+    });
     const user = await prisma.user.delete({
       where: { id: userId },
     });


### PR DESCRIPTION
# refactor deleting users and fix bugs in delete

- admins can delete users from a user's profile

- when deleting a user, also deleting all references in other tables to that user
 (cascade on delete for many-to-many relationships don't work on prisma right now so just did it manually, an issue @ethanlee16 also mentioned in another PR)
issue prisma/prisma#2057

## How to Test/Use PR feature

1) from the "users/admin" page, click on any user
2) from the users profile, try deleting a user
3) should take you to the users dashboard after clicking "delete"

## PR Checklist

Does your branch (check if true):
[X] work when you run `yarn build`?
[X] successfully run `yarn:db-migrate up` without yielding any errors?
[X] successfully run `yarn prisma introspect` without yielding any errors?
[X] successfully run `yarn dev` and support all changes that your branch intends to perform?

## Screenshots

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/65790318/100533221-b5de8480-31b6-11eb-952d-1c733289220c.png">

<img width="1335" alt="image" src="https://user-images.githubusercontent.com/65790318/100533222-c0008300-31b6-11eb-9046-fd2978f4e00a.png">



CC: @erinysong
