### PR TITLE
Update admin/user/update API Endpoint to allow for role updating 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
   "css.validate": false,
-  "prisma.plugin.nextjs.hasPrompted": true
+  "prisma.plugin.nextjs.hasPrompted": true,
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
 }

--- a/components/Combobox.tsx
+++ b/components/Combobox.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useCombobox } from "downshift";
-import { User } from "@prisma/client";
 import debounce from "lodash.debounce";
 import { UserRoleLabel, UserRoleType } from "interfaces";
+import { User } from "@prisma/client";
 import Button from "./Button";
 import Card from "./Card";
 
@@ -25,7 +25,7 @@ const getInputPlayers = async (
 type Props = React.PropsWithChildren<{
   selectedPlayers: User[];
   setSelectedPlayers: React.Dispatch<React.SetStateAction<User[]>>;
-  role: string;
+  role?: string;
 }>;
 
 const Combobox: React.FC<Props> = ({

--- a/pages/api/admin/users/update.ts
+++ b/pages/api/admin/users/update.ts
@@ -6,6 +6,7 @@ import { validateBody } from "pages/api/helpers";
 import flattenUserRoles from "utils/flattenUserRoles";
 import sanitizeUser from "utils/sanitizeUser";
 import { adminOnlyHandler } from "../helpers";
+import { ViewingPermissionDTO } from "../roles/create";
 
 const prisma = new PrismaClient();
 
@@ -16,7 +17,7 @@ export type UpdateUserDTO = {
   phoneNumber?: string;
   emailVerified?: Date;
   image?: string;
-  roles: [UserRoleType];
+  roles?: [ViewingPermissionDTO];
   hashedPassword?: string;
 };
 
@@ -40,59 +41,103 @@ const handler = async (
   res: NextApiResponse
 ): Promise<void> => {
   try {
-    const { roles = [], ...userInfo } = req.body;
-    const user =
-      roles[0] === "Admin"
-        ? await prisma.user.update({
-            where: { id: userInfo.id || Number(req.query.id) },
-            data: {
-              name: userInfo.name,
-              email: userInfo.email,
-              phoneNumber: userInfo.phoneNumber,
-              emailVerified: userInfo.emailVerified,
-              image: userInfo.image,
-              hashedPassword: userInfo.hashedPassword,
-              roles: {
-                deleteMany: {
-                  type: {
-                    not: undefined,
-                  },
-                },
-                create: {
-                  type: UserRoleType.Admin,
-                },
+    const userInfo = req.body;
+
+    let user;
+
+    const roles =
+      (userInfo.roles &&
+        userInfo.roles.map((role) =>
+          JSON.parse((role as unknown) as string)
+        )) ||
+      [];
+
+    if (roles && roles[0].type === "Admin") {
+      user = await prisma.user.update({
+        where: { id: userInfo.id || Number(req.query.id) },
+        data: {
+          name: userInfo.name,
+          email: userInfo.email,
+          phoneNumber: userInfo.phoneNumber,
+          emailVerified: userInfo.emailVerified,
+          image: userInfo.image,
+          hashedPassword: userInfo.hashedPassword,
+          roles: {
+            deleteMany: {
+              type: {
+                not: undefined,
               },
             },
-            include: {
-              roles: true,
+            create: {
+              type: UserRoleType.Admin,
             },
-          })
-        : await prisma.user.update({
-            where: { id: userInfo.id || Number(req.query.id) },
-            data: {
-              name: userInfo.name,
-              email: userInfo.email,
-              phoneNumber: userInfo.phoneNumber,
-              emailVerified: userInfo.emailVerified,
-              image: userInfo.image,
-              hashedPassword: userInfo.hashedPassword,
-              roles: {
-                updateMany: {
-                  data: {
-                    type: roles[0],
-                  },
-                  where: {
+          },
+        },
+        include: {
+          roles: true,
+        },
+      });
+    } else {
+      user = await prisma.user.update({
+        where: { id: userInfo.id || Number(req.query.id) },
+        data: {
+          name: userInfo.name,
+          email: userInfo.email,
+          phoneNumber: userInfo.phoneNumber,
+          emailVerified: userInfo.emailVerified,
+          image: userInfo.image,
+          hashedPassword: userInfo.hashedPassword,
+          ...(roles !== undefined
+            ? {
+                roles: {
+                  deleteMany: {
                     type: {
                       not: undefined,
                     },
                   },
                 },
+              }
+            : {}),
+        },
+        include: {
+          roles: true,
+        },
+      });
+
+      if (roles !== undefined) {
+        const allResults = await Promise.all(
+          roles.map((role) => {
+            return prisma.role.create({
+              data: {
+                type: role.type,
+                relatedPlayer: role.relatedPlayerId
+                  ? {
+                      connect: {
+                        id: role.relatedPlayerId,
+                      },
+                    }
+                  : {},
+                user: {
+                  connect: {
+                    id: role.userId,
+                  },
+                },
               },
-            },
-            include: {
-              roles: true,
-            },
-          });
+              include: {
+                user: {
+                  include: {
+                    roles: true,
+                  },
+                },
+              },
+            });
+          })
+        );
+
+        user = allResults[allResults.length - 1].user;
+      }
+    }
+
     if (!user) {
       res
         .status(404)


### PR DESCRIPTION
# Update admin/user/update API Endpoint to allow for role updating 

- updated front end to allow adding and deleting linked players on the user profile page as well

- also included update to vscode settings to allow auto-prettier styling on save

## TODO (if applicable)

- did not finish styling but will do so by next sprint task, just wanted to get the functionality out so that Joy and CJ could use it

## How to Test/Use PR feature

go to a mentor's profile page and try editing their related players

## PR Checklist

Does your branch (check if true):
[X] work when you run `yarn build`?
[X] successfully run `yarn:db-migrate up` without yielding any errors?
[X] successfully run `yarn prisma introspect` without yielding any errors?
[X] successfully run `yarn dev` and support all changes that your branch intends to perform?

## Related PRs

@christopher-grey @joyydong finished the update user API to allow editing of related players! tagging so hopefully you will get notified when it gets merged & so that you can reference code if needed

## Migrations

N/A

## Screenshots

Before Editing
![image](https://user-images.githubusercontent.com/65790318/109375866-f82a6700-7874-11eb-9c34-0c3760b2a3c8.png)

Edit Page
![image](https://user-images.githubusercontent.com/65790318/109375873-0aa4a080-7875-11eb-9466-1a7d72285135.png)

After Saving Changes
![image](https://user-images.githubusercontent.com/65790318/109375883-198b5300-7875-11eb-826c-55136b90f238.png)


CC: @sydbui
