### PR TITLE
Some last fixes on the User Invites ("Your Pending Invites") table

### DIFF
--- a/pages/api/admin/users/create.ts
+++ b/pages/api/admin/users/create.ts
@@ -50,14 +50,19 @@ const handler = async (
         ...(role
           ? {
               roles: {
-                create: linkedPlayers?.map((playerID: number) => ({
-                  type: role,
-                  relatedPlayer: {
-                    connect: {
-                      id: playerID,
-                    },
-                  },
-                })),
+                create:
+                  linkedPlayers && linkedPlayers.length > 0
+                    ? linkedPlayers?.map((playerID: number) => ({
+                        type: role,
+                        relatedPlayer: {
+                          connect: {
+                            id: playerID,
+                          },
+                        },
+                      }))
+                    : {
+                        type: role,
+                      },
               },
             }
           : undefined),

--- a/pages/api/admin/users/update.ts
+++ b/pages/api/admin/users/update.ts
@@ -82,6 +82,33 @@ const handler = async (
           userInvites: true,
         },
       });
+    } else if (roles && roles[0].type === "Player") {
+      user = await prisma.user.update({
+        where: { id: userInfo.id || Number(req.query.id) },
+        data: {
+          name: userInfo.name,
+          email: userInfo.email,
+          phoneNumber: userInfo.phoneNumber,
+          status: userInfo.status,
+          image: userInfo.image,
+          hashedPassword: userInfo.hashedPassword,
+          updatedAt: new Date(),
+          roles: {
+            deleteMany: {
+              type: {
+                not: undefined,
+              },
+            },
+            create: {
+              type: UserRoleType.Player,
+            },
+          },
+        },
+        include: {
+          roles: true,
+          userInvites: true,
+        },
+      });
     } else {
       user = await prisma.user.update({
         where: { id: userInfo.id || Number(req.query.id) },


### PR DESCRIPTION
# Finishing touches on Your Pending Invites table
Updated the `update` api to clear linked players if `role === players` (admin case had already been covered)

## TODO (if applicable)

- [ ] save button for individual invites page [BACKLOGGED]

## How to Test/Use PR feature

- go to http://localhost:3000/admin/invite and click one of the pending (non-admin or non-player) invites in the table 
- change the role to player or admin and save
- check db to verify that this user no longer has any linked player

## PR Checklist

Does your branch (check if true):
- [x] work when you run `yarn build`?
- [x] successfully run `yarn:db-migrate up` without yielding any errors?
- [x] successfully run `yarn prisma introspect` without yielding any errors?
- [x] successfully run `yarn dev` and support all changes that your branch intends to perform?



CC: @sydbui
