### PR TITLE
Handle case where filterPlayerProfileWrite receives an admin user

### DIFF
--- a/utils/filterPlayerProfileWrite.ts
+++ b/utils/filterPlayerProfileWrite.ts
@@ -12,6 +12,9 @@ const filterPlayerProfileWrite = (
   profileFields: ProfileFieldUpdateManyWithoutUserInput
 ): ProfileFieldUpdateManyWithoutUserInput => {
   const filteredProfileFields: ProfileFieldUpdateManyWithoutUserInput = {};
+  if (user.defaultRole.type === UserRoleType.Admin) {
+    return profileFields;
+  }
   if (profileFields.create) {
     filteredProfileFields.create = (Array.isArray(profileFields.create)
       ? profileFields.create


### PR DESCRIPTION
Hotfixes an issue where `filterPlayerProfileWrite` was not handling scenarios where the `user` argument was an Admin-type user.

## How to Test/Use PR feature

* Validate that admin users can update player profiles.
* Validate that admin users can create player profiles.

## PR Checklist

Does your branch (check if true):
- [x] work when you run `yarn build`?
- [x] successfully run `yarn:db-migrate up` without yielding any errors?
- [x] successfully run `yarn prisma introspect` without yielding any errors?
- [x] successfully run `yarn dev` and support all changes that your branch intends to perform?

## Related PRs

Issue introduced by #142.

CC: @sydbui
