### PR TITLE
Pending Invites Table bug

### DIFF
--- a/pages/admin/invite/[id].tsx
+++ b/pages/admin/invite/[id].tsx
@@ -147,6 +147,13 @@ const UserInvitation: React.FunctionComponent<gsspProps> = ({
       }) as unknown) as ViewingPermissionDTO;
       linkedPlayers.push(body);
     });
+    let role = [
+      (JSON.stringify({
+        type: currRole,
+        userId: user?.id,
+      }) as unknown) as ViewingPermissionDTO,
+    ];
+    role = linkedPlayers.length > 0 ? linkedPlayers : role;
     try {
       const response = await fetch(`/api/admin/users/${user?.id}`, {
         method: "PATCH",
@@ -156,7 +163,7 @@ const UserInvitation: React.FunctionComponent<gsspProps> = ({
           email: values.email,
           name: `${values.firstName} ${values.lastName}`,
           phoneNumber: values.phoneNumber,
-          roles: linkedPlayers,
+          roles: role,
           sendEmail: true,
         } as UpdateUserDTO),
       });


### PR DESCRIPTION
# Fixed Pending Invites Table bug 

- bug fix with "undefined role" in pending invites table
(used to have this error when we try to resend invite without linked players)
![image](https://user-images.githubusercontent.com/34170094/112783115-65abed80-9003-11eb-8102-bfce0f99b3c7.png)


## How to Test/Use PR feature

- go to http://localhost:3000/admin/invite 
- click on an invite in the pending invites table 
- resend an invite without any linked players and verify that it doesn't error

## PR Checklist

Does your branch (check if true):
- [x] work when you run `yarn build`?
- [x] successfully run `yarn:db-migrate up` without yielding any errors?
- [x] successfully run `yarn prisma introspect` without yielding any errors?
- [x] successfully run `yarn dev` and support all changes that your branch intends to perform?


CC: @sydbui
