### PR TITLE
Add resend invite confirmation

### DIFF
--- a/components/Combobox.tsx
+++ b/components/Combobox.tsx
@@ -27,6 +27,7 @@ type Props = React.PropsWithChildren<{
   setSelectedPlayers: React.Dispatch<React.SetStateAction<User[]>>;
   role: string | undefined;
   promptOff?: boolean;
+  callback?: () => void;
 }>;
 
 const Combobox: React.FC<Props> = ({
@@ -34,6 +35,7 @@ const Combobox: React.FC<Props> = ({
   setSelectedPlayers,
   role,
   promptOff,
+  callback,
 }: Props) => {
   const [inputPlayers, setInputPlayers] = useState<User[]>([]);
   const [query, setQuery] = useState("");
@@ -52,6 +54,7 @@ const Combobox: React.FC<Props> = ({
     isOpen: focused,
     items: inputPlayers,
     onInputValueChange: debounce(async ({ inputValue }) => {
+      if (callback) callback();
       setInputPlayers(await getInputPlayers(inputValue, selectedPlayers));
     }, 300),
   });
@@ -79,6 +82,7 @@ const Combobox: React.FC<Props> = ({
   }, [reset, selectedItem, selectedPlayers, setSelectedPlayers]);
 
   const onDelete = (user: User): void => {
+    if (callback) callback();
     setSelectedPlayers(
       selectedPlayers.filter((selectedPlayer: User) => selectedPlayer !== user)
     );

--- a/components/Player/Profile.tsx
+++ b/components/Player/Profile.tsx
@@ -510,7 +510,6 @@ const Profile: React.FunctionComponent<Props> = ({ player }: Props) => {
   const [selectedCategory, setSelectedCategory] = useState(
     ProfileCategory.Overview
   );
-  console.log("Absences is:", player.absences);
   return (
     <div>
       <div className="flex flex-row text-sm text-center">

--- a/pages/admin/invite/[id].tsx
+++ b/pages/admin/invite/[id].tsx
@@ -1,4 +1,4 @@
-import { useRouter } from "next/router";
+import { NextRouter, useRouter } from "next/router";
 import DashboardLayout from "components/DashboardLayout";
 import React, { useState, useEffect } from "react";
 import Button from "components/Button";
@@ -13,6 +13,58 @@ import { User } from "@prisma/client";
 import prisma from "utils/prisma";
 import Combobox from "components/Combobox";
 import { ViewingPermissionDTO } from "pages/api/admin/roles/create";
+import Modal from "components/Modal";
+
+interface ResendConfirmationProps {
+  isResending: boolean;
+  setIsResending: React.Dispatch<React.SetStateAction<boolean>>;
+  setSubmitter: React.Dispatch<React.SetStateAction<string>>;
+}
+
+const ResendConfirmation: React.FunctionComponent<ResendConfirmationProps> = ({
+  isResending,
+  setIsResending,
+  setSubmitter,
+}) => {
+  return (
+    <Modal open={Boolean(isResending)} className="max-w-xl">
+      <p className="text-lg font-medium text-dark">
+        Re-sending this invite will save invite changes
+      </p>
+      <p className="text-sm font-normal text-dark pt-2 pb-10">
+        By re-sending this invite, any changes you&apos;ve made will
+        automatically be saved and updated.
+      </p>
+      <div className="mb-2 flex float-right">
+        <Button
+          className="px-10 py-2 mr-5 hover:bg-button text-unselected bg-opacity-0"
+          onClick={() => {
+            setIsResending(false);
+          }}
+        >
+          Don&apos;t Send
+        </Button>
+        <Button
+          className="button-primary px-10 py-2 text-blue hover:bg-blue-muted bg-opacity-0"
+          type="submit"
+          onClick={() => {
+            setSubmitter("resend");
+          }}
+        >
+          Save and Send
+        </Button>
+      </div>
+    </Modal>
+  );
+};
+
+interface ResendConfirmationProps {
+  isResending: boolean;
+  setIsResending: React.Dispatch<React.SetStateAction<boolean>>;
+  setSubmitter: React.Dispatch<React.SetStateAction<string>>;
+  router: NextRouter;
+  id: number;
+}
 
 interface AdminEditUserInviteFormValues {
   firstName: string;
@@ -101,6 +153,7 @@ const UserInvitation: React.FunctionComponent<gsspProps> = ({
         redirect: "follow",
       });
       const data = await response.json();
+
       // check user is pending
       if (data.user.status !== UserStatus.PendingUserAcceptance) {
         throw new Error("Invalid user invite");
@@ -109,10 +162,43 @@ const UserInvitation: React.FunctionComponent<gsspProps> = ({
     };
     getUser();
   }, [id]);
+
+  const [notSaved, setNotSaved] = useState(false);
+
+  useEffect(() => {
+    const confirmationMessage =
+      "You have unsaved changes. Leaving this page will discard any unsaved changes.";
+    const beforeUnloadHandler = (e: BeforeUnloadEvent): string => {
+      (e || window.event).returnValue = confirmationMessage;
+      return confirmationMessage; // Gecko + Webkit, Safari, Chrome etc.
+    };
+    const beforeRouteHandler = (url: string): void => {
+      // eslint-disable-next-line no-alert
+      if (router.pathname !== url && !window.confirm(confirmationMessage)) {
+        router.events.emit("routeChangeError");
+        // eslint-disable-next-line no-throw-literal
+        throw `Route change to "${url}" was aborted (this error can be safely ignored). See https://github.com/zeit/next.js/issues/2476.`;
+      }
+    };
+    if (notSaved) {
+      window.addEventListener("beforeunload", beforeUnloadHandler);
+      router.events.on("routeChangeStart", beforeRouteHandler);
+    } else {
+      window.removeEventListener("beforeunload", beforeUnloadHandler);
+      router.events.off("routeChangeStart", beforeRouteHandler);
+    }
+    return () => {
+      window.removeEventListener("beforeunload", beforeUnloadHandler);
+      router.events.off("routeChangeStart", beforeRouteHandler);
+    };
+  }, [notSaved, router.events, router.pathname]);
+
   const [submitting, setSubmitting] = useState(false);
+  const [submitter, setSubmitter] = useState<string>("");
   const [error, setError] = useState("");
   const [currRole, setCurrRole] = useState<UserRoleType>();
   const [selectedPlayers, setSelectedPlayers] = useState<User[]>([]);
+  const [isResending, setIsResending] = useState(false);
   const {
     errors,
     register,
@@ -164,13 +250,15 @@ const UserInvitation: React.FunctionComponent<gsspProps> = ({
           name: `${values.firstName} ${values.lastName}`,
           phoneNumber: values.phoneNumber,
           roles: role,
-          sendEmail: true,
+          sendEmail: submitter === "resend",
         } as UpdateUserDTO),
       });
+
       if (!response.ok) {
         throw await response.json();
       } else {
         setUser((await response.json()).user);
+        setNotSaved(false);
         router.push("/admin/invite");
       }
     } catch (err) {
@@ -185,7 +273,11 @@ const UserInvitation: React.FunctionComponent<gsspProps> = ({
       <div className="mx-16 mt-24">
         <h1 className="text-3xl font-display font-medium mb-2">Edit Invite</h1>
         <p>Description</p>
-        <form className="mt-10" onSubmit={handleSubmit(onSubmit)}>
+        <form
+          className="mt-10"
+          id="editInviteForm"
+          onSubmit={handleSubmit(onSubmit)}
+        >
           <fieldset>
             <legend className="text-lg font-semibold mb-8">
               Basic Information
@@ -203,6 +295,7 @@ const UserInvitation: React.FunctionComponent<gsspProps> = ({
                   defaultValue={user?.name?.split(" ")[0]}
                   placeholder="e.g., Cristiano"
                   ref={register}
+                  onChange={() => setNotSaved(true)}
                 />
               ) : (
                 <input
@@ -211,6 +304,7 @@ const UserInvitation: React.FunctionComponent<gsspProps> = ({
                   name="firstName"
                   placeholder="e.g., Cristiano"
                   ref={register}
+                  onChange={() => setNotSaved(true)}
                 />
               )}
             </FormField>
@@ -231,6 +325,7 @@ const UserInvitation: React.FunctionComponent<gsspProps> = ({
                   }
                   placeholder="e.g., Ronaldo"
                   ref={register}
+                  onChange={() => setNotSaved(true)}
                 />
               ) : (
                 <input
@@ -239,6 +334,7 @@ const UserInvitation: React.FunctionComponent<gsspProps> = ({
                   name="lastName"
                   placeholder="e.g., Ronaldo"
                   ref={register}
+                  onChange={() => setNotSaved(true)}
                 />
               )}
             </FormField>
@@ -255,6 +351,7 @@ const UserInvitation: React.FunctionComponent<gsspProps> = ({
                   defaultValue={user?.email}
                   placeholder="e.g., soccer@fifa.com"
                   ref={register}
+                  onChange={() => setNotSaved(true)}
                 />
               ) : (
                 <input
@@ -263,6 +360,7 @@ const UserInvitation: React.FunctionComponent<gsspProps> = ({
                   name="email"
                   placeholder="e.g., soccer@fifa.com"
                   ref={register}
+                  onChange={() => setNotSaved(true)}
                 />
               )}
             </FormField>
@@ -279,6 +377,7 @@ const UserInvitation: React.FunctionComponent<gsspProps> = ({
                   defaultValue={user?.phoneNumber}
                   placeholder="e.g., 123-456-7890"
                   ref={register}
+                  onChange={() => setNotSaved(true)}
                 />
               ) : (
                 <input
@@ -287,6 +386,7 @@ const UserInvitation: React.FunctionComponent<gsspProps> = ({
                   name="phoneNumber"
                   placeholder="e.g., 123-456-7890"
                   ref={register}
+                  onChange={() => setNotSaved(true)}
                 />
               )}
             </FormField>
@@ -299,7 +399,10 @@ const UserInvitation: React.FunctionComponent<gsspProps> = ({
                     name="role"
                     id={role}
                     defaultValue={role}
-                    onChange={() => setCurrRole(role)}
+                    onChange={() => {
+                      setNotSaved(true);
+                      setCurrRole(role);
+                    }}
                     checked={currRole === role}
                     ref={register}
                   />
@@ -328,6 +431,7 @@ const UserInvitation: React.FunctionComponent<gsspProps> = ({
                   selectedPlayers={selectedPlayers}
                   setSelectedPlayers={setSelectedPlayers}
                   role={currRole}
+                  callback={() => setNotSaved(true)}
                 />
               </FormField>
             </div>
@@ -335,7 +439,19 @@ const UserInvitation: React.FunctionComponent<gsspProps> = ({
           <hr />
           <div className="my-10">
             <div className="mb-2 flex">
-              <Button className="button-primary px-10 py-2 mr-5" type="submit">
+              <Button
+                className="button-primary px-10 py-2 mr-5"
+                type="submit"
+                onClick={() => setSubmitter("save")}
+              >
+                Save Changes
+              </Button>
+              <Button
+                className="button-primary px-10 py-2 mr-5"
+                onClick={() => {
+                  setIsResending(true);
+                }}
+              >
                 Re-Send Invite
               </Button>
               <Button
@@ -349,6 +465,13 @@ const UserInvitation: React.FunctionComponent<gsspProps> = ({
             </div>
             {error && <p className="text-red-600 text-sm">{error}</p>}
           </div>
+          {user && (
+            <ResendConfirmation
+              isResending={isResending}
+              setIsResending={setIsResending}
+              setSubmitter={setSubmitter}
+            />
+          )}
         </form>
       </div>
     </DashboardLayout>


### PR DESCRIPTION
# Resend Invite Confirmation

- adds resend invite confirmation modal to user invite edit page

- checks and notifies for unsaved changes (couldn't figure out how to make a custom synchronous modal, so i just used `window.confirm` instead)

## TODO (if applicable)

_Checklist of any action items that still must be done on this PR_

- [ ] figure out how to resolve merge conflicts (findUnique is erroring for some reason but idk why bc i ran yarn & typical prisma commands)
inside `admin/invite/[id]`
![image](https://user-images.githubusercontent.com/65790318/114269235-a1a76100-99ba-11eb-9c9f-6496a5ceab50.png)


## How to Test/Use PR feature

1. Go to .../admin/invite, then click on a pending invite
2. try editing the invite without saving and navigating away and check to make sure there's a pop up confirmation
3. when you click resend invite, a modal should pop up

## PR Checklist

Does your branch (check if true):
[X] work when you run `yarn build`?
[X] successfully run `yarn:db-migrate up` without yielding any errors?
[X] successfully run `yarn prisma introspect` without yielding any errors?
[X] successfully run `yarn dev` and support all changes that your branch intends to perform?

## Related PRs

_Optional - any related PRs you're waiting on, or PRs that will conflict, etc_

## Migrations

N/A

## Screenshots

![image](https://user-images.githubusercontent.com/65790318/114269104-bd5e3780-99b9-11eb-9354-1da3da7f3ae3.png)
![image](https://user-images.githubusercontent.com/65790318/114269120-d5ce5200-99b9-11eb-9d63-9bdb3f541459.png)


CC: @sydbui
