### PR TITLE
Create form follow-on updates

### DIFF
--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,18 +1,59 @@
+import { Dialog, Transition } from "@headlessui/react";
 import React from "react";
 
 type Props = React.PropsWithChildren<{
   open?: boolean;
+  onClose: () => void;
   className?: string;
 }>;
 
-const Modal: React.FC<Props> = ({ children, open, className }: Props) => {
-  return open ? (
-    <div className="fixed pin top-0 left-0 w-full h-full overscroll-auto bg-dark bg-opacity-50 flex justify-center items-center">
-      <div className={`bg-white rounded px-10 pt-12 pb-8 ${className ?? ""}`}>
-        {children}
-      </div>
-    </div>
-  ) : null;
+const Modal: React.FC<Props> = ({
+  children,
+  open = false,
+  onClose,
+  className,
+}: Props) => {
+  return (
+    <Transition show={open} as={React.Fragment}>
+      <Dialog
+        open={open}
+        onClose={onClose}
+        className="fixed inset-0 overscroll-auto w-full"
+        static
+      >
+        <div className="min-h-screen flex items-center">
+          <Transition.Child
+            as={React.Fragment}
+            enter="ease-out duration-300"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leave="ease-in duration-200"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <Dialog.Overlay className="fixed inset-0 bg-dark bg-opacity-25" />
+          </Transition.Child>
+          <Transition.Child
+            as={React.Fragment}
+            enter="transition duration-100 ease-out"
+            enterFrom="transform scale-95 opacity-0"
+            enterTo="transform scale-100 opacity-100"
+            leave="transition duration-75 ease-out"
+            leaveFrom="transform scale-100 opacity-100"
+            leaveTo="transform scale-95 opacity-0"
+          >
+            <div
+              className={`fixed z-10 inset-x-0 m-auto bg-white rounded-lg px-10 pt-12 pb-8 shadow-xl w-1/2 h-auto ${
+                className ?? ""
+              }`}
+            >
+              {children}
+            </div>
+          </Transition.Child>
+        </div>
+      </Dialog>
+    </Transition>
+  );
 };
 
 export default Modal;

--- a/components/Player/AbsenceTable.tsx
+++ b/components/Player/AbsenceTable.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import { Absence, AbsenceReason, AbsenceType } from "@prisma/client";
+import { IProfileField } from "interfaces";
 import dayjs from "lib/day";
+import toast from "lib/toast";
+import isAbsence from "utils/isAbsence";
 import useCanEditField from "utils/useCanEditField";
 import EditMore from "./EditMore";
 import ProfileFieldEditorModal from "./ProfileFieldEditorModal";
@@ -69,8 +72,14 @@ const AbsenceTable: React.FC<Props> = ({ absenceType, absences }: Props) => {
       <div className="mt-8 grid grid-rows-2 w-full justify-end">
         <ProfileFieldEditorModal
           fieldKey="absence"
-          onComplete={() => {
-            // TODO: Dispatch notification
+          onComplete={(updated?: Absence | IProfileField) => {
+            if (updated && isAbsence(updated)) {
+              toast.success(
+                `Absence for ${dayjs(updated.date).format(
+                  "MMMMM YYYY"
+                )} has been created!`
+              );
+            }
           }}
         />
       </div>

--- a/components/Player/AbsenceTable.tsx
+++ b/components/Player/AbsenceTable.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Absence, AbsenceReason, AbsenceType } from "@prisma/client";
 import dayjs from "lib/day";
+import useCanEditField from "utils/useCanEditField";
 import EditMore from "./EditMore";
 import ProfileFieldEditorModal from "./ProfileFieldEditorModal";
 
@@ -15,12 +16,13 @@ const AbsencePillColors: Record<AbsenceReason, string> = {
 };
 
 const AbsenceTable: React.FC<Props> = ({ absenceType, absences }: Props) => {
+  const canEdit = useCanEditField("absence", absenceType);
   const filteredAbsences = absences
     .filter((absence: Absence) => absence.type === absenceType)
     .sort((a: Absence, b: Absence) => Number(a.date) - Number(b.date));
 
   return (
-    <div className="mb-16 text-sm">
+    <div className="mb-8 text-sm">
       <h2 className="text-xl font-semibold my-4">{absenceType} Absences</h2>
       <table className="w-full mb-4">
         <thead>
@@ -28,7 +30,7 @@ const AbsenceTable: React.FC<Props> = ({ absenceType, absences }: Props) => {
             <th className="w-3/12 pl-5 font-semibold">Date</th>
             <th className="w-2/12 font-semibold">Score</th>
             <th className="w-5/12 font-semibold">Description</th>
-            <th className="w-1/12 font-semibold">Actions</th>
+            {canEdit && <th className="w-1/12 font-semibold">Actions</th>}
           </tr>
         </thead>
         <tbody>
@@ -51,9 +53,11 @@ const AbsenceTable: React.FC<Props> = ({ absenceType, absences }: Props) => {
                   </span>
                 </td>
                 <td>{absence.description}</td>
-                <td className="w-1/12">
-                  <EditMore absenceId={absence.id} />
-                </td>
+                {canEdit && (
+                  <td className="w-1/12">
+                    <EditMore absenceId={absence.id} />
+                  </td>
+                )}
               </tr>
             ))}
         </tbody>
@@ -62,7 +66,7 @@ const AbsenceTable: React.FC<Props> = ({ absenceType, absences }: Props) => {
         <p>Total {absenceType} Absences</p>
         <p className="font-semibold">{filteredAbsences.length}</p>
       </div>
-      <div className=" mb-16 mt-8 grid grid-rows-2 w-full justify-end">
+      <div className="mt-8 grid grid-rows-2 w-full justify-end">
         <ProfileFieldEditorModal
           fieldKey="absence"
           onComplete={() => {

--- a/components/Player/EditMore.tsx
+++ b/components/Player/EditMore.tsx
@@ -49,13 +49,8 @@ const EditMore: React.FunctionComponent<EditProps> = (props: EditProps) => {
       <Menu>
         {({ open }) => (
           <>
-            <Menu.Button className="focus:outline-none">
-              <button
-                type="button"
-                className="relative focus:outline-none flex align-center justify-center"
-              >
-                <Icon type="more" className="h-5 ml-4 fill-current" />
-              </button>
+            <Menu.Button className="relative focus:outline-none flex align-center justify-center">
+              <Icon type="more" className="h-5 ml-4 fill-current" />
             </Menu.Button>
             <Transition
               show={open}

--- a/components/Player/EditMore.tsx
+++ b/components/Player/EditMore.tsx
@@ -6,6 +6,11 @@ import Icon from "components/Icon";
 import Modal from "components/Modal";
 import { StandaloneProfileFieldEditor } from "components/Player/ProfileFieldEditorModal";
 import { IProfileField, NumericProfileFields } from "interfaces/user";
+import dayjs from "lib/day";
+import toast from "lib/toast";
+import { deserializeProfileFieldValue } from "utils/buildUserProfile";
+import labelProfileField from "utils/labelProfileField";
+import isAbsence from "utils/isAbsence";
 import DeleteField from "./DeleteField";
 import ProfileContext from "./ProfileContext";
 
@@ -104,21 +109,48 @@ const EditMore: React.FunctionComponent<EditProps> = (props: EditProps) => {
           </>
         )}
       </Menu>
-      <Modal open={selectedOption === "edit"} className="w-2/3">
+      <Modal
+        open={selectedOption === "edit"}
+        className="w-1/2"
+        onClose={() => setSelectedOption(null)}
+      >
         <StandaloneProfileFieldEditor
           field={field}
-          onComplete={() => {
+          onComplete={(updated?: IProfileField | Absence) => {
             setSelectedOption(null);
-            // TODO: Dispatch notification
+            if (updated) {
+              toast.success(
+                `${labelProfileField(updated)} for ${dayjs(
+                  isAbsence(updated)
+                    ? updated.date
+                    : deserializeProfileFieldValue(
+                        updated as IProfileField<NumericProfileFields>
+                      )?.date
+                ).format("MMMM YYYY")} has been updated!`
+              );
+            }
           }}
         />
       </Modal>
-      <Modal open={selectedOption === "delete"} className="w-2/3">
+      <Modal
+        open={selectedOption === "delete"}
+        onClose={() => setSelectedOption(null)}
+      >
         <DeleteField
           field={field}
-          onComplete={() => {
+          onComplete={(deleted?: IProfileField | Absence) => {
             setSelectedOption(null);
-            // TODO: Dispatch notification
+            if (deleted) {
+              toast.success(
+                `${labelProfileField(deleted)} for ${dayjs(
+                  isAbsence(deleted)
+                    ? deleted.date
+                    : deserializeProfileFieldValue(
+                        deleted as IProfileField<NumericProfileFields>
+                      )?.date
+                ).format("MMMM YYYY")} has been deleted.`
+              );
+            }
           }}
         />
       </Modal>

--- a/components/Player/PlayerFormLayout/ProgressBar.tsx
+++ b/components/Player/PlayerFormLayout/ProgressBar.tsx
@@ -4,17 +4,25 @@ type BarProps = {
   fill: boolean;
   content: string;
   title: string;
+  disabled?: boolean;
 };
 
 const BarTab: React.FunctionComponent<BarProps> = ({
   fill,
   content,
   title,
+  disabled,
 }: BarProps) => {
   const link = `/admin/players/create/${title}`;
   return (
     <Link href={link}>
-      <div role="button">
+      <button
+        type="button"
+        className={`text-left focus:outline-none ${
+          disabled ? "cursor-not-allowed" : "cursor-pointer"
+        }`}
+        disabled={disabled}
+      >
         <div
           className={
             fill
@@ -23,9 +31,13 @@ const BarTab: React.FunctionComponent<BarProps> = ({
           }
         />
         <p className="font-bold mt-2 text-xs">{content}</p>
-      </div>
+      </button>
     </Link>
   );
+};
+
+BarTab.defaultProps = {
+  disabled: false,
 };
 
 export default BarTab;

--- a/components/Player/PlayerFormLayout/index.tsx
+++ b/components/Player/PlayerFormLayout/index.tsx
@@ -1,5 +1,6 @@
 import { ProfileCategory } from "interfaces";
 import { useRouter } from "next/router";
+import { useCreateProfileContext } from "pages/admin/players/create/[profileCategory]";
 import React from "react";
 import BarTab from "./ProgressBar";
 
@@ -18,6 +19,7 @@ export const usePlayerFormCategoryIndex = (): number => {
 
 const PlayerFormLayout: React.FC<Props> = ({ children }: Props) => {
   const currentTabIndex = usePlayerFormCategoryIndex();
+  const { state } = useCreateProfileContext();
 
   return (
     <div className="text-dark">
@@ -30,6 +32,7 @@ const PlayerFormLayout: React.FC<Props> = ({ children }: Props) => {
               fill={currentTabIndex >= index}
               content={`${displayIndex}. ${category}`}
               title={category}
+              disabled={state.player === null}
             />
           );
         })}

--- a/components/Player/Profile.tsx
+++ b/components/Player/Profile.tsx
@@ -238,8 +238,8 @@ const Profile: React.FunctionComponent<Props> = ({ player }: Props) => {
   }, [player, dispatch]);
 
   return (
-    <div>
-      <div className="flex flex-row text-sm text-center">
+    <div className="pb-24">
+      <div className="flex flex-row flex-wrap text-sm text-center">
         {Object.values(ProfileCategory)
           .filter(
             (category: ProfileCategory) =>
@@ -252,7 +252,7 @@ const Profile: React.FunctionComponent<Props> = ({ player }: Props) => {
             <button
               key={category}
               type="button"
-              className={`navigation-tab mr-8 ${
+              className={`navigation-tab mr-6 ${
                 selectedCategory === category
                   ? "navigation-tab-highlighted"
                   : ""

--- a/components/Player/ProfileFieldEditor.tsx
+++ b/components/Player/ProfileFieldEditor.tsx
@@ -325,7 +325,7 @@ const ProfileFieldEditor: React.FC<Props> = (props: Props) => {
               </p>
               <ProfileFieldEditorModal fieldKey={field.key} />
             </div>
-            <ValueHistoryTable values={field.history} />
+            <ValueHistoryTable fieldKey={field.key} values={field.history} />
           </div>
         );
       }

--- a/components/Player/ProfileFieldEditorModal.tsx
+++ b/components/Player/ProfileFieldEditorModal.tsx
@@ -34,7 +34,7 @@ export const StandaloneProfileFieldEditor: React.FC<
     if ("field" in props) {
       try {
         await updateField(props.field);
-        onComplete?.();
+        onComplete?.(props.field);
       } catch (err) {
         setError(err.message);
       }
@@ -146,7 +146,11 @@ const ProfileFieldEditorModal: React.FC<Props> = ({
           {intentLabel}
         </Button>
       )}
-      <Modal open={modalOpen} className="w-1/2">
+      <Modal
+        open={modalOpen}
+        className="w-1/2"
+        onClose={() => setModalOpen(false)}
+      >
         <StandaloneProfileFieldEditor
           onComplete={wrappedOnComplete}
           {...props}

--- a/components/Player/ProfileFieldEditorModal.tsx
+++ b/components/Player/ProfileFieldEditorModal.tsx
@@ -3,8 +3,13 @@ import { Absence, ProfileFieldKey } from "@prisma/client";
 import Button from "components/Button";
 import Modal from "components/Modal";
 import React, { useCallback, useContext, useState } from "react";
-import { IProfileField } from "interfaces/user";
+import {
+  IProfileField,
+  ProfileFieldValueDeserializedTypes,
+  ProfileFieldValues,
+} from "interfaces/user";
 import PropTypes from "prop-types";
+import { serializeProfileFieldValue } from "utils/buildUserProfile";
 import labelProfileField from "utils/labelProfileField";
 import isAbsence from "utils/isAbsence";
 import useCanEditField from "utils/useCanEditField";
@@ -51,7 +56,20 @@ export const StandaloneProfileFieldEditor: React.FC<
           return;
         }
         await createField(props.fieldKey, draft, state.player.id);
-        onComplete?.();
+        onComplete?.(
+          props.fieldKey === "absence"
+            ? (draft as Absence)
+            : {
+                createdAt: new Date(),
+                id: 0,
+                userId: state.player.id,
+                key: props.fieldKey,
+                value: serializeProfileFieldValue(
+                  draft as ProfileFieldValueDeserializedTypes[ProfileFieldValues[ProfileFieldKey]],
+                  props.fieldKey
+                ),
+              }
+        );
       } catch (err) {
         setError(err.message);
       }

--- a/components/Player/ValueHistoryGraph.tsx
+++ b/components/Player/ValueHistoryGraph.tsx
@@ -221,6 +221,7 @@ const ValueHistoryGraph: React.FC<ValueHistoryGraphProps> = ({
         </VictoryGroup>
         {values.map((datum) => (
           <VictoryLine
+            key={datum.date.unix()}
             style={{
               data: {
                 stroke: ({ active }) =>

--- a/components/Player/ValueHistoryTable.tsx
+++ b/components/Player/ValueHistoryTable.tsx
@@ -6,9 +6,11 @@ import {
 import dayjs from "lib/day";
 import React from "react";
 import { deserializeProfileFieldValue } from "utils/buildUserProfile";
+import useCanEditField from "utils/useCanEditField";
 import EditMore from "./EditMore";
 
 type Props = {
+  fieldKey: NumericProfileFields;
   values: (
     | IProfileField<NumericProfileFields>
     | UncreatedProfileField<NumericProfileFields>
@@ -18,53 +20,59 @@ type Props = {
 };
 
 const ValueHistoryTable: React.FC<Props> = ({
+  fieldKey,
   values,
   startDate,
   endDate,
-}: Props) => (
-  <table className="w-full mt-4">
-    <thead>
-      <tr className="h-10 text-left text-unselected tr-border">
-        <th className="w-3/12 pl-5 font-semibold">Date</th>
-        <th className="w-2/12 font-semibold">Value</th>
-        <th className="w-5/12 font-semibold">Description</th>
-        <th className="w-1/12 font-semibold">Actions</th>
-      </tr>
-    </thead>
-    <tbody>
-      {values
-        .sort((a, b) => {
-          const aValue = deserializeProfileFieldValue(a);
-          const bValue = deserializeProfileFieldValue(b);
-          return (bValue?.date.unix() ?? 0) - (aValue?.date.unix() ?? 0);
-        })
-        .map((field) => {
-          const value = deserializeProfileFieldValue(field);
-          if (startDate && endDate && value) {
-            if (
-              value.date.isAfter(endDate, "day") ||
-              value.date.isBefore(startDate, "day")
-            ) {
-              return null;
+}: Props) => {
+  const canEdit = useCanEditField(fieldKey);
+  return (
+    <table className="w-full mt-4">
+      <thead>
+        <tr className="h-10 text-left text-unselected tr-border">
+          <th className="w-3/12 pl-5 font-semibold">Date</th>
+          <th className="w-2/12 font-semibold">Value</th>
+          <th className="w-5/12 font-semibold">Description</th>
+          {canEdit && <th className="w-1/12 font-semibold">Actions</th>}
+        </tr>
+      </thead>
+      <tbody>
+        {values
+          .sort((a, b) => {
+            const aValue = deserializeProfileFieldValue(a);
+            const bValue = deserializeProfileFieldValue(b);
+            return (bValue?.date.unix() ?? 0) - (aValue?.date.unix() ?? 0);
+          })
+          .map((field) => {
+            const value = deserializeProfileFieldValue(field);
+            if (startDate && endDate && value) {
+              if (
+                value.date.isAfter(endDate, "day") ||
+                value.date.isBefore(startDate, "day")
+              ) {
+                return null;
+              }
             }
-          }
 
-          return (
-            <tr key={field.id} className="h-16 tr-border">
-              <td className="w-3/12 px-5">
-                {dayjs(value?.date).format("MMM YYYY")}
-              </td>
-              <td className="w-2/12">{value?.value}</td>
-              <td>{value?.comment}</td>
-              <td className="w-1/12">
-                <EditMore fieldKey={field.key} fieldId={field.id} />
-              </td>
-            </tr>
-          );
-        })}
-    </tbody>
-  </table>
-);
+            return (
+              <tr key={field.id} className="h-16 tr-border">
+                <td className="w-3/12 px-5">
+                  {dayjs(value?.date).format("MMM YYYY")}
+                </td>
+                <td className="w-2/12">{value?.value}</td>
+                <td>{value?.comment}</td>
+                {canEdit && (
+                  <td className="w-1/12">
+                    <EditMore fieldKey={field.key} fieldId={field.id} />
+                  </td>
+                )}
+              </tr>
+            );
+          })}
+      </tbody>
+    </table>
+  );
+};
 
 ValueHistoryTable.defaultProps = {
   startDate: undefined,

--- a/components/Player/ValueHistoryTable.tsx
+++ b/components/Player/ValueHistoryTable.tsx
@@ -27,7 +27,7 @@ const ValueHistoryTable: React.FC<Props> = ({
 }: Props) => {
   const canEdit = useCanEditField(fieldKey);
   return (
-    <table className="w-full mt-4">
+    <table className="w-full mt-4 text-sm">
       <thead>
         <tr className="h-10 text-left text-unselected tr-border">
           <th className="w-3/12 pl-5 font-semibold">Date</th>

--- a/components/Player/ValueHistoryView.tsx
+++ b/components/Player/ValueHistoryView.tsx
@@ -166,7 +166,9 @@ const ValueHistoryView: React.FC<Props> = ({
           >
             {Object.entries(IntervalWindowLabels).map(
               ([interval, label]: [string, string]) => (
-                <option value={interval}>{label}</option>
+                <option key={interval} value={interval}>
+                  {label}
+                </option>
               )
             )}
           </select>
@@ -196,6 +198,7 @@ const ValueHistoryView: React.FC<Props> = ({
       </div>
       {historyView === "table" && (
         <ValueHistoryTable
+          fieldKey={fieldKey}
           values={values}
           startDate={startDate}
           endDate={endDate}

--- a/components/Player/ValueHistoryView.tsx
+++ b/components/Player/ValueHistoryView.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import dayjs from "lib/day";
 
-import { ProfileField } from "@prisma/client";
+import { Absence, ProfileField } from "@prisma/client";
 import Button from "components/Button";
 import Icon, { IconType } from "components/Icon";
 import {
@@ -11,7 +11,9 @@ import {
   ProfileFieldValues,
   UncreatedProfileField,
 } from "interfaces";
+import toast from "lib/toast";
 import { deserializeProfileFieldValue } from "utils/buildUserProfile";
+import isAbsence from "utils/isAbsence";
 import labelProfileField from "utils/labelProfileField";
 import colors from "../../constants/colors";
 import ProfileFieldEditorModal from "./ProfileFieldEditorModal";
@@ -218,8 +220,18 @@ const ValueHistoryView: React.FC<Props> = ({
       <div className="mb-16 mt-8 grid grid-rows-2 w-full justify-end">
         <ProfileFieldEditorModal
           fieldKey={fieldKey}
-          onComplete={() => {
-            // TODO: Dispatch notification
+          onComplete={(updated?: Absence | IProfileField) => {
+            if (updated) {
+              toast.success(
+                `${labelProfileField(updated)} for ${dayjs(
+                  isAbsence(updated)
+                    ? updated.date
+                    : deserializeProfileFieldValue(
+                        updated as IProfileField<NumericProfileFields>
+                      )?.date
+                ).format("MMMM YYYY")} has been created!`
+              );
+            }
           }}
         />
       </div>

--- a/components/userRequest.tsx
+++ b/components/userRequest.tsx
@@ -1,12 +1,12 @@
+import { Dialog } from "@headlessui/react";
+import { UserStatus } from "@prisma/client";
 import React, { useEffect, useState } from "react";
 import Button from "components/Button";
 import { DeleteUserDTO } from "pages/api/admin/users/delete";
 import Link from "next/link";
 import { UpdateUserDTO } from "pages/api/admin/users/update";
 import { DefaultRole } from "interfaces/user";
-import { UserStatus } from "@prisma/client";
-import toast, { Toaster } from "react-hot-toast";
-import colors from "constants/colors";
+import toast from "lib/toast";
 import Modal from "./Modal";
 
 const UserRequestDashboardItem: React.FunctionComponent<UserRequest> = ({
@@ -21,16 +21,7 @@ const UserRequestDashboardItem: React.FunctionComponent<UserRequest> = ({
 }) => {
   const [isDeleting, setIsDeleting] = useState(false);
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  const toasty = () =>
-    toast.success("Account request accepted!", {
-      duration: 2000,
-      iconTheme: { primary: colors.dark, secondary: colors.button },
-      style: {
-        background: colors.dark,
-        color: colors.button,
-        margin: "50px",
-      },
-    });
+  const toasty = () => toast.success("Account request accepted!");
   const deleteUser = async (): Promise<void> => {
     try {
       const response = await fetch("/api/admin/users/delete", {
@@ -69,8 +60,14 @@ const UserRequestDashboardItem: React.FunctionComponent<UserRequest> = ({
 
   return (
     <div>
-      <Modal className="mb-2" open={Boolean(isDeleting)}>
-        <h1 className="font-semibold">Decline account request?</h1>
+      <Modal
+        className="mb-2"
+        open={isDeleting}
+        onClose={() => setIsDeleting(false)}
+      >
+        <Dialog.Title className="font-semibold">
+          Decline account request?
+        </Dialog.Title>
         <p className="mb-6">
           Are you sure you want to decline {name}&apos;s account request?
         </p>
@@ -136,7 +133,6 @@ const UserRequestDashboardItem: React.FunctionComponent<UserRequest> = ({
             >
               Accept
             </Button>
-            <Toaster position="bottom-left" reverseOrder={false} />
           </div>
         </div>
       </div>

--- a/lib/toast.ts
+++ b/lib/toast.ts
@@ -1,0 +1,27 @@
+/// <reference types="react" />
+import colors from "constants/colors";
+// eslint-disable-next-line import/no-named-default
+import { default as originalHotToast } from "react-hot-toast";
+
+type Rendarable = JSX.Element | string | number | null;
+
+const toast = (
+  type: "error" | "success" | "loading",
+  message: Rendarable
+): string => {
+  return originalHotToast[type](message, {
+    duration: 2000,
+    iconTheme: { primary: colors.dark, secondary: colors.button },
+    style: {
+      background: colors.dark,
+      color: colors.button,
+      margin: "50px",
+    },
+  });
+};
+
+export default {
+  success: (message: Rendarable): string => toast("success", message),
+  error: (message: Rendarable): string => toast("error", message),
+  loading: (message: Rendarable): string => toast("loading", message),
+};

--- a/pages/[role]/[id].tsx
+++ b/pages/[role]/[id].tsx
@@ -16,11 +16,10 @@ import prisma from "utils/prisma";
 import Combobox from "components/Combobox";
 import { ViewingPermissionDTO } from "pages/api/admin/roles/create";
 import useSessionInfo from "utils/useSessionInfo";
-import toast, { Toaster } from "react-hot-toast";
+import toast from "react-hot-toast";
 import { signOut } from "next-auth/client";
 import sanitizeUser from "utils/sanitizeUser";
 import flattenUserRoles from "utils/flattenUserRoles";
-import colors from "../../constants/colors";
 
 type gsspProps = {
   user?: IUser;
@@ -522,15 +521,7 @@ const UserProfile: React.FunctionComponent<gsspProps> = ({
         } else {
           toastMessage = "User account deactivated";
         }
-        toast.success(toastMessage, {
-          duration: 2000,
-          iconTheme: { primary: colors.dark, secondary: colors.button },
-          style: {
-            background: colors.dark,
-            color: colors.button,
-            margin: "50px",
-          },
-        });
+        toast.success(toastMessage);
       }
     } catch (err) {
       setError(err.message);
@@ -660,7 +651,6 @@ const UserProfile: React.FunctionComponent<gsspProps> = ({
                     </span>
                     .
                   </div>
-                  <Toaster position="bottom-left" />
                   {error && <p className="text-red-600 text-sm">{error}</p>}
                 </div>
               </div>

--- a/pages/[role]/players/[id].tsx
+++ b/pages/[role]/players/[id].tsx
@@ -15,6 +15,7 @@ import buildUserProfile, {
 import filterPlayerProfileRead from "utils/filterPlayerProfileRead";
 import flattenUserRoles from "utils/flattenUserRoles";
 import { IPlayer } from "interfaces";
+import { Dialog } from "@headlessui/react";
 
 type Props = {
   player?: IPlayer;
@@ -93,10 +94,14 @@ const PlayerProfilePage: React.FunctionComponent<Props> = ({
             </p>
           </div>
         </div>
-        <Modal className="w-2/5" open={showModal}>
-          <h1 className="text-dark text-3xl font-medium mb-2">
+        <Modal
+          className="w-2/5"
+          open={showModal}
+          onClose={() => setShowModal(false)}
+        >
+          <Dialog.Title className="text-dark text-3xl font-medium mb-2">
             Dashboard Created!
-          </h1>
+          </Dialog.Title>
           <p className="text-dark mb-10">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
             semper, massa sed tempor rhoncus, tortor lectus luctus orci,

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,6 +8,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import "../styles/globals.css";
 import NProgress from "nprogress";
 import "nprogress/nprogress.css";
+import { Toaster } from "react-hot-toast";
 
 export const AuthContext = React.createContext<AuthenticatedSessionInfo | null>(
   null
@@ -83,6 +84,7 @@ const MyApp: React.FC<AppProps> = ({ Component, pageProps }) => {
     return (
       <StateMachineProvider>
         <Component {...pageProps} />
+        <Toaster position="bottom-left" reverseOrder={false} />
       </StateMachineProvider>
     );
   }
@@ -99,6 +101,7 @@ const MyApp: React.FC<AppProps> = ({ Component, pageProps }) => {
         }
       >
         <Component {...pageProps} />
+        <Toaster position="bottom-left" reverseOrder={false} />
       </AuthContext.Provider>
     </StateMachineProvider>
   );

--- a/pages/admin/invite/[id].tsx
+++ b/pages/admin/invite/[id].tsx
@@ -16,6 +16,7 @@ import { ViewingPermissionDTO } from "pages/api/admin/roles/create";
 import flattenUserRoles from "utils/flattenUserRoles";
 import sanitizeUser from "utils/sanitizeUser";
 import Modal from "components/Modal";
+import { Dialog } from "@headlessui/react";
 
 interface ResendConfirmationProps {
   isResending: boolean;
@@ -29,10 +30,14 @@ const ResendConfirmation: React.FunctionComponent<ResendConfirmationProps> = ({
   setSubmitter,
 }) => {
   return (
-    <Modal open={Boolean(isResending)} className="max-w-xl">
-      <p className="text-lg font-medium text-dark">
+    <Modal
+      open={isResending}
+      onClose={() => setIsResending(false)}
+      className="max-w-xl"
+    >
+      <Dialog.Title className="text-lg font-medium text-dark">
         Re-sending this invite will save invite changes
-      </p>
+      </Dialog.Title>
       <p className="text-sm font-normal text-dark pt-2 pb-10">
         By re-sending this invite, any changes you&apos;ve made will
         automatically be saved and updated.

--- a/pages/admin/invite/index.tsx
+++ b/pages/admin/invite/index.tsx
@@ -27,7 +27,11 @@ const AdminInvitePage: React.FC = () => {
           <PendingInvitesTable />
         </div>
       </div>
-      <Modal className="w-2/5" open={Boolean(router.query.success)}>
+      <Modal
+        className="w-2/5"
+        open={Boolean(router.query.success)}
+        onClose={() => router.replace("/admin/invite")}
+      >
         <h1 className="text-dark text-3xl font-medium mb-2">Invite Sent!</h1>
         <p className="text-dark mb-10">
           Your invitee will have ? days to accept their invite.

--- a/pages/admin/invite/userAccountPage/[id].tsx
+++ b/pages/admin/invite/userAccountPage/[id].tsx
@@ -12,10 +12,9 @@ import Joi from "joi";
 import { joiResolver } from "@hookform/resolvers/joi";
 import { useForm } from "react-hook-form";
 import Icon from "components/Icon";
-import toast, { Toaster } from "react-hot-toast";
+import toast from "react-hot-toast";
 import Modal from "components/Modal";
 import { ViewingPermissionDTO } from "pages/api/admin/roles/create";
-import colors from "../../../../constants/colors";
 
 interface AdminEditUserFormValues {
   firstName: string;
@@ -33,16 +32,7 @@ interface EditUserProps {
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const toasty = () =>
-  toast.success("Account request accepted!", {
-    duration: 2000,
-    iconTheme: { primary: colors.dark, secondary: colors.button },
-    style: {
-      background: colors.dark,
-      color: colors.button,
-      margin: "50px",
-    },
-  });
+const toasty = () => toast.success("Account request accepted!");
 
 const AdminEditUserFormSchema = Joi.object<AdminEditUserFormValues>({
   firstName: Joi.string().trim().required(),
@@ -119,11 +109,8 @@ const EditUser: React.FunctionComponent<EditUserProps> = ({
   }
 
   return (
-    <Modal
-      className=" bg-white rounded w-3/4 px-10 pt-12 pb-8"
-      open={Boolean(isEditing)}
-    >
-      <div className="mx-16 mt-24">
+    <Modal open={Boolean(isEditing)} onClose={() => setIsEditing(false)}>
+      <div className="m-8">
         <h1 className="text-3xl font-display font-medium mb-2">
           Basic Information
         </h1>
@@ -357,7 +344,11 @@ const UserAccountPage: React.FunctionComponent<UserRequest> = () => {
   return (
     <DashboardLayout>
       <div className="flex-col mx-16 mt-14">
-        <Modal className="mb-2" open={Boolean(isDeleting)}>
+        <Modal
+          className="mb-2"
+          open={Boolean(isDeleting)}
+          onClose={() => setIsDeleting(false)}
+        >
           <h1 className="font-semibold">Decline account request?</h1>
           <p className="mb-6">
             Are you sure you want to decline {user?.name}&apos;s account
@@ -456,7 +447,6 @@ const UserAccountPage: React.FunctionComponent<UserRequest> = () => {
               >
                 Accept
               </Button>
-              <Toaster position="bottom-left" reverseOrder={false} />
             </div>
           </div>
         </div>

--- a/pages/admin/players/create/[profileCategory].tsx
+++ b/pages/admin/players/create/[profileCategory].tsx
@@ -201,7 +201,7 @@ const CreatePlayerProfilePage: React.FC = () => {
   return (
     <DashboardLayout>
       <div className="form flex mx-20 mt-24 flex-col">
-        <p className="py-6 text-2xl h-16 tracking-wide font-medium">
+        <p className="py-6 text-2xl h-16 font-medium">
           Create a new player profile
         </p>
         <PlayerFormLayout>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -38,7 +38,7 @@ a {
   }
 
   .input {
-    @apply bg-button p-2 font-light rounded-lg;
+    @apply bg-button p-2 font-light rounded-lg border border-transparent;
   }
 
   .input:focus {

--- a/utils/useCanEditField.ts
+++ b/utils/useCanEditField.ts
@@ -1,0 +1,47 @@
+import { AbsenceType, ProfileFieldKey, UserRoleType } from "@prisma/client";
+import ProfileContext from "components/Player/ProfileContext";
+import {
+  AttendanceAccessDefinitionsByRole,
+  ProfileAccessDefinitionsByRole,
+} from "lib/access/definitions";
+import resolveAccessValue from "lib/access/resolve";
+import { useContext } from "react";
+import useSessionInfo from "./useSessionInfo";
+
+const useCanEditField = (
+  key: ProfileFieldKey | "absence",
+  absenceType?: AbsenceType
+): boolean => {
+  const { user } = useSessionInfo();
+  const {
+    state: { player },
+  } = useContext(ProfileContext);
+
+  if (!player) {
+    return false;
+  }
+
+  let canEdit = false;
+  if (user.defaultRole.type === UserRoleType.Admin) {
+    canEdit = true;
+  } else if (key === "absence") {
+    canEdit = resolveAccessValue(
+      AttendanceAccessDefinitionsByRole[user.defaultRole.type][
+        absenceType ?? AbsenceType.Academic
+      ] ?? false,
+      "write",
+      player,
+      user
+    );
+  } else {
+    canEdit = resolveAccessValue(
+      ProfileAccessDefinitionsByRole[user.defaultRole.type][key] ?? false,
+      "write",
+      player,
+      user
+    );
+  }
+  return canEdit;
+};
+
+export default useCanEditField;


### PR DESCRIPTION
* Resolves #221: prevents moving forward in the create form if the player has not been supplied.
* Makes buttons for creating engagement scores/absences sensitive to lib/access definitions
* Adds back toast notifications to creates/updates made in ValueHistoryTable and AbsenceTable, standardizes toast settings in lib/toast
* Refactors Modal to use @headlessui/dialog, with stylistic updates and accessibility improvements
  * Resolves #217.

## How to Test/Use PR feature

* Validate that the repro case in #221 is resolved; navigation to future steps should be prevented in UI if player is not selected.
* Validate that for non-admin users, engagement score/absence creation is not available or displayed in their respective table views
* Validate that toast notifications are appearing for creates/updates of engagement scores and absences
* Validate that Modal display styling has not regressed across the app

## PR Checklist

Does your branch (check if true):
- [x] work when you run `yarn build`?
- [x] successfully run `yarn:db-migrate up` without yielding any errors?
- [x] successfully run `yarn prisma introspect` without yielding any errors?
- [x] successfully run `yarn dev` and support all changes that your branch intends to perform?


## Screenshots

New modal: more subtle backdrop, entrance/exit animation, shadow, sizing changes. Thanks to Headless UI, scroll locking + focus trapping are now default behavior in modals as well!

![image](https://user-images.githubusercontent.com/2977329/115171254-8520be00-a077-11eb-8593-a73760e58b88.png)

Also resolves #217:
![image](https://user-images.githubusercontent.com/2977329/115171511-0415f680-a078-11eb-9225-9492fc3d4743.png)


CC: @sydbui
