### PR TITLE
Sendgrid on accepted user account

### DIFF
--- a/components/userRequest.tsx
+++ b/components/userRequest.tsx
@@ -47,7 +47,10 @@ const UserRequestDashboardItem: React.FunctionComponent<UserRequest> = ({
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
-        body: JSON.stringify({ status: UserStatus.Active } as UpdateUserDTO),
+        body: JSON.stringify({
+          status: UserStatus.Active,
+          userAccepted: true,
+        } as UpdateUserDTO),
       });
       if (!response.ok) {
         throw await response.json();

--- a/lib/notify/sendgrid.ts
+++ b/lib/notify/sendgrid.ts
@@ -12,6 +12,7 @@ export default class SendgridNotifier implements Notifier {
   templates: Record<NotificationType, string> = {
     [NotificationType.ForgotPassword]: "d-9e3ecf30ca4846a68e1e879db5105974",
     [NotificationType.SignUpInvitation]: "d-3ad525e2c11840e59dce1a51d1d89004",
+    [NotificationType.RequestAccepted]: "d-d3d3822022b548589003f1a005227616",
   };
 
   async setup(): Promise<void> {

--- a/lib/notify/types.ts
+++ b/lib/notify/types.ts
@@ -1,6 +1,7 @@
 export enum NotificationType {
   SignUpInvitation = "SIGN_UP_INVITATION",
   ForgotPassword = "FORGOT_PASSWORD_REQUEST",
+  RequestAccepted = "REQUEST_ACCEPTED",
 }
 
 type BaseNotificationMeta = {

--- a/pages/admin/invite/[id].tsx
+++ b/pages/admin/invite/[id].tsx
@@ -252,7 +252,7 @@ const UserInvitation: React.FunctionComponent<gsspProps> = ({
           name: `${values.firstName} ${values.lastName}`,
           phoneNumber: values.phoneNumber,
           roles: role,
-          sendEmail: submitter === "resend",
+          resendInvite: submitter === "resend",
         } as UpdateUserDTO),
       });
 

--- a/pages/admin/invite/userAccountPage/[id].tsx
+++ b/pages/admin/invite/userAccountPage/[id].tsx
@@ -331,6 +331,7 @@ const UserAccountPage: React.FunctionComponent<UserRequest> = () => {
         body: JSON.stringify({
           status: UserStatus.Active,
           roles: linkedPlayers,
+          userAccepted: true,
         } as UpdateUserDTO),
       });
       if (!response.ok) {

--- a/pages/api/admin/users/update.ts
+++ b/pages/api/admin/users/update.ts
@@ -20,7 +20,8 @@ export type UpdateUserDTO = {
   roles?: [ViewingPermissionDTO];
   status?: UserStatus;
   hashedPassword?: string;
-  sendEmail?: boolean;
+  resendInvite?: boolean;
+  userAccepted?: boolean;
 };
 
 const expectedBody = Joi.object<UpdateUserDTO>({
@@ -34,7 +35,8 @@ const expectedBody = Joi.object<UpdateUserDTO>({
   image: Joi.string(),
   roles: Joi.array().items(Joi.string()),
   hashedPassword: Joi.string(),
-  sendEmail: Joi.boolean(),
+  resendInvite: Joi.boolean(),
+  userAccepted: Joi.boolean(),
   status: Joi.string(),
 });
 
@@ -177,11 +179,17 @@ const handler = async (
         .json({ statusCode: 404, message: "User does not exist." });
     }
 
-    if (userInfo.sendEmail) {
+    if (userInfo.resendInvite) {
       await Notifier.sendNotification(NotificationType.SignUpInvitation, {
         email: user.email,
         inviteCodeId: user.userInvites[0].id,
       });
+    }
+    if (userInfo.userAccepted) {
+      console.log("sending request accepted email");
+      // await Notifier.sendNotification(NotificationType.RequestAccepted, {
+      //   email: user.email,
+      // });
     }
     res.json({
       message: "Successfully updated user.",

--- a/pages/api/admin/users/update.ts
+++ b/pages/api/admin/users/update.ts
@@ -186,10 +186,9 @@ const handler = async (
       });
     }
     if (userInfo.userAccepted) {
-      console.log("sending request accepted email");
-      // await Notifier.sendNotification(NotificationType.RequestAccepted, {
-      //   email: user.email,
-      // });
+      await Notifier.sendNotification(NotificationType.RequestAccepted, {
+        email: user.email,
+      });
     }
     res.json({
       message: "Successfully updated user.",


### PR DESCRIPTION
# Sendgrid email for after user account has been accepted

- SendGrid for userInvites (when an admin Accepts their account it sends an email that lets the user know that their account has been accepted and they can now log in) 

## TODO (if applicable)

- [x] log on to sendgrid and make email template

## How to Test/Use PR feature

accept an entry under Invitation Requests on http://localhost:3000/admin/invite and check that an email has been sent

## PR Checklist

Does your branch (check if true):
- [x] work when you run `yarn build`?
- [x] successfully run `yarn:db-migrate up` without yielding any errors?
- [x] successfully run `yarn prisma introspect` without yielding any errors?
- [x] successfully run `yarn dev` and support all changes that your branch intends to perform?

CC: @sydbui
