### PR TITLE
Allow empty fields to show up if the viewer has edit access

### DIFF
--- a/components/Player/Profile.tsx
+++ b/components/Player/Profile.tsx
@@ -1,4 +1,4 @@
-import { AbsenceType, ProfileFieldKey } from "@prisma/client";
+import { AbsenceType, ProfileFieldKey, UserRoleType } from "@prisma/client";
 import React, { useContext, useState } from "react";
 import Icon from "components/Icon";
 import {
@@ -7,6 +7,9 @@ import {
   ProfileCategoryIcons,
   ProfileFieldsByCategory,
 } from "interfaces";
+import { ProfileAccessDefinitionsByRole } from "lib/access/definitions";
+import resolveAccessValue from "lib/access/resolve";
+import useSessionInfo from "utils/useSessionInfo";
 import AbsenceTable from "./AbsenceTable";
 import ProfileFieldCell from "./ProfileFieldCell";
 import { NotesTable } from "./NotesTable";
@@ -133,15 +136,29 @@ const Profile: React.FunctionComponent<Props> = ({ player }: Props) => {
     ProfileCategory.Overview
   );
 
+  const { user } = useSessionInfo();
+  const {
+    defaultRole: { type: currentUserType },
+  } = user;
+
   return (
     <div className="pb-24">
       <div className="flex flex-row flex-wrap text-sm text-center">
         {Object.values(ProfileCategory)
           .filter(
             (category: ProfileCategory) =>
-              ProfileFieldsByCategory[category].some(
-                (key: ProfileFieldKey) => player.profile?.[key]
-              ) ||
+              ProfileFieldsByCategory[category].some((key: ProfileFieldKey) => {
+                const canEdit =
+                  currentUserType === UserRoleType.Admin ||
+                  resolveAccessValue(
+                    ProfileAccessDefinitionsByRole[currentUserType][key] ??
+                      false,
+                    "write",
+                    player,
+                    user
+                  );
+                return canEdit || player.profile?.[key];
+              }) ||
               (category === ProfileCategory.Attendance && player.absences) ||
               (category === ProfileCategory.Notes && player.playerNotes)
           )

--- a/components/Player/ProfileFieldCell.tsx
+++ b/components/Player/ProfileFieldCell.tsx
@@ -61,7 +61,7 @@ const ProfileFieldCell: React.FC<ProfileFieldCellProps> = ({
     deserializedValue
   );
 
-  if (!editing && (!canRead || deserializedValue === null)) {
+  if (!canRead || (!canEdit && deserializedValue === null)) {
     return null;
   }
 

--- a/components/Player/ProfileFieldCell.tsx
+++ b/components/Player/ProfileFieldCell.tsx
@@ -134,40 +134,46 @@ const ProfileFieldCell: React.FC<ProfileFieldCellProps> = ({
 
   switch (valueType) {
     case ProfileFieldValue.TimeElapsed: {
-      const value = deserializedValue as ProfileFieldValueDeserializedTypes[typeof valueType];
+      const value = deserializedValue as
+        | ProfileFieldValueDeserializedTypes[typeof valueType]
+        | null;
 
       return (
         <TextLayout title={title}>
           {editing ? (
             <ProfileFieldEditor profileField={profileField} />
           ) : (
-            `${value.minutes()} minutes ${value.seconds()} seconds`
+            value && `${value.minutes()} minutes ${value.seconds()} seconds`
           )}
         </TextLayout>
       );
     }
     case ProfileFieldValue.DistanceMeasured: {
-      const value = deserializedValue as ProfileFieldValueDeserializedTypes[typeof valueType];
+      const value = deserializedValue as
+        | ProfileFieldValueDeserializedTypes[typeof valueType]
+        | null;
 
       return (
         <TextLayout title={title}>
           {editing ? (
             <ProfileFieldEditor profileField={profileField} />
           ) : (
-            `${value.feet} ft. ${value.inches} in.`
+            value && `${value.feet} ft. ${value.inches} in.`
           )}
         </TextLayout>
       );
     }
     case ProfileFieldValue.File: {
-      const value = deserializedValue as ProfileFieldValueDeserializedTypes[typeof valueType];
+      const value = deserializedValue as
+        | ProfileFieldValueDeserializedTypes[typeof valueType]
+        | null;
 
       return (
         <TextLayout title={title}>
           {editing ? (
             <ProfileFieldEditor profileField={profileField} />
           ) : (
-            `${value.key}`
+            value && `${value.key}`
           )}
         </TextLayout>
       );


### PR DESCRIPTION
* Prevent returning null if the viewer of a profile has edit access, from ProfileFieldCell
* Allow a category to appear if any field within it should be editable by the viewer

## How to Test/Use PR feature

- Create a sparse player profile from the player creation form, meaning that some fields (e.g., Academic Engagement Score) do not appear.
- Validate that the resulting player profile continues to show all tabs and fields from an admin's perspective, and allow the entry of data while viewing an already-created profile.

## PR Checklist

Does your branch (check if true):
- [x] work when you run `yarn build`?
- [x] successfully run `yarn:db-migrate up` without yielding any errors?
- [x] successfully run `yarn prisma introspect` without yielding any errors?
- [x] successfully run `yarn dev` and support all changes that your branch intends to perform?


CC: @sydbui
