### PR TITLE
Make URL types clickable and allow for YouTube video embeds

### DIFF
--- a/components/Player/ProfileFieldCell.tsx
+++ b/components/Player/ProfileFieldCell.tsx
@@ -1,4 +1,5 @@
 import { ProfileFieldKey, UserRoleType } from "@prisma/client";
+import Icon from "components/Icon";
 import {
   IProfileFieldBuilt,
   ProfileFieldKeysOfProfileValueType,
@@ -227,6 +228,66 @@ const ProfileFieldCell: React.FC<ProfileFieldCellProps> = ({
             <ProfileFieldEditorModal fieldKey={fieldKey} shouldToastOnSuccess />
           </div>
         </LargeFieldCellLayout>
+      );
+    }
+    case ProfileFieldValue.URL: {
+      const value = deserializedValue as
+        | ProfileFieldValueDeserializedTypes[typeof valueType]
+        | null;
+      let videoId: string | null | undefined;
+      if (value) {
+        try {
+          const url = new URL(value);
+          if (
+            url.hostname === "www.youtube.com" ||
+            url.hostname === "youtube.com"
+          ) {
+            videoId = url.searchParams.get("v");
+          }
+        } catch {
+          // No-op
+        }
+      }
+      if (videoId) {
+        return (
+          <TextLayout title={title}>
+            {editing ? (
+              <ProfileFieldEditor profileField={profileField} />
+            ) : (
+              <iframe
+                className="mt-2"
+                width="640"
+                height="360"
+                src={`https://www.youtube.com/embed/${videoId}`}
+                frameBorder="0"
+                title={title}
+              />
+            )}
+          </TextLayout>
+        );
+      }
+
+      return (
+        <TextLayout title={title}>
+          {editing ? (
+            <ProfileFieldEditor profileField={profileField} />
+          ) : (
+            value && (
+              <a
+                className="text-blue underline flex"
+                href={value}
+                target="_blank"
+                rel="noreferrer"
+              >
+                {value}
+                <Icon
+                  className="stroke-current w-2 transform -rotate-90 ml-1"
+                  type="chevron"
+                />
+              </a>
+            )
+          )}
+        </TextLayout>
       );
     }
     case ProfileFieldValue.Text:


### PR DESCRIPTION
* Make URLs clickable in view mode
* Detect YouTube URLs and automatically embed if available

## How to Test/Use PR feature

* Validate that Highlights and Intro Video fields are appearing as clickable links on the profile.
* Try adding a YouTube URL, i.e. "https://www.youtube.com/watch?v=kR77WlHRZrs" to one of the URL fields.
* Validate that YouTube embeds are appearing inline with the profile.

## PR Checklist

Does your branch (check if true):

- [x] successfully run `yarn dev` and support all changes that your branch intends to perform?

## Screenshots

YouTube embed:
![image](https://user-images.githubusercontent.com/2977329/116841483-30f4fe00-ab8e-11eb-8a9b-ad6c087b1262.png)

Link click:
![image](https://user-images.githubusercontent.com/2977329/116841503-436f3780-ab8e-11eb-8f5f-309aa798fe23.png)


CC: @sydbui
