### PR TITLE
Set signatureVersion for S3, restrict fork sync to pushes on main

### DIFF
--- a/.github/workflows/forks.yml
+++ b/.github/workflows/forks.yml
@@ -1,6 +1,8 @@
 name: Mirror updates to forks
 
-on: [push, delete]
+on:
+  push:
+    branches: [main]
 
 jobs:
   to_github_ogsc:

--- a/pages/api/admin/users/addImage.ts
+++ b/pages/api/admin/users/addImage.ts
@@ -7,14 +7,12 @@ const handler = async (
   req: NextApiRequest,
   res: NextApiResponse
 ): Promise<void> => {
-  aws.config.update({
+  const s3 = new aws.S3({
     accessKeyId: process.env.ACCESS_KEY,
     secretAccessKey: process.env.SECRET_KEY,
     region: process.env.REGION,
     signatureVersion: "v4",
   });
-
-  const s3 = new aws.S3();
   const post = await s3.createPresignedPost({
     Bucket: process.env.BUCKET_NAME,
     Fields: {

--- a/pages/api/profilePicture/index.ts
+++ b/pages/api/profilePicture/index.ts
@@ -7,7 +7,12 @@ export default async (
 ): Promise<void> => {
   const { key } = req.query;
   try {
-    const s3 = new aws.S3();
+    const s3 = new aws.S3({
+      accessKeyId: process.env.ACCESS_KEY,
+      secretAccessKey: process.env.SECRET_KEY,
+      region: process.env.REGION,
+      signatureVersion: "v4",
+    });
     const params = {
       Bucket: process.env.BUCKET_NAME,
       Key: `${process.env.PATH_NAME}${key}`,


### PR DESCRIPTION
* Sets S3 config options with `signatureVersion` set as "v4" in both places (production bucket requires v4 signatures)
* Update fork sync job option to only listen on pushes to main

## How to Test/Use PR feature

* Regression test image uploads and validate that image viewing/uploading still works as expected.

## PR Checklist

Does your branch (check if true):

- [x] successfully run `yarn dev` and support all changes that your branch intends to perform?

CC: @sydbui
